### PR TITLE
Dockerfile uses the existing repository, will not overwrite config.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu
 
 RUN sed 's/main$/main universe/' -i /etc/apt/sources.list && apt-get update
 RUN apt-get install -y git-core python-pip build-essential python-dev libevent1-dev -y
-RUN git clone https://github.com/dotcloud/docker-registry.git /docker-registry
+ADD . /docker-registry
 
 RUN cd /docker-registry && pip install -r requirements.txt
-RUN cp /docker-registry/config_sample.yml /docker-registry/config.yml
+RUN cp --no-clobber /docker-registry/config_sample.yml /docker-registry/config.yml
 
 EXPOSE 5000
 


### PR DESCRIPTION
With this change, I can...
- control which version of the registry I build (it's the version where the Dockerfile is located)
- control the registry configuration that will be used, because I can create a config.yml file without it being overwritten by the sample one.

... without modifying the Dockerfile.

The downside is that the image cache is blown by that new "ADD" step. The "RUN git clone" that it replaces doesn't play well with the cache, either.
