### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Run the Registry
 Install the system requirements for building a Python library:
 
 ```
-sudo apt-get install build-essential libpython-dev libevent-dev
+sudo apt-get install build-essential python-dev libevent-dev
 ```
 
 Then install the Registry app:
 
 ```
-pip install -r requirements.txt
+sudo pip install -r requirements.txt
 ```
 
 And run it (for a dev environment):


### PR DESCRIPTION
- Changes package name from libpython-dev to python-dev
- Need sudo for "pip install -r requirements.txt"
