### PR TITLE
fix python dev headers package inREADME

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run the Registry
 Install the system requirements for building a Python library:
 
 ```
-sudo apt-get install build-essential libpython-dev libevent-dev
+sudo apt-get install build-essential python-dev libevent-dev
 ```
 
 Then install the Registry app:


### PR DESCRIPTION
libpython-dev is not an actual apt package (at least in Ubuntu 12.04). python-dev is the right one
