### PR TITLE
registry image name is now docker-registry (was registry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run the Registry
 ### The fast way:
 
 ```
-docker run samalba/registry
+docker run samalba/docker-registry
 ```
 
 NOTE: The container will try to allocate the port 5000 by default, if the port


### PR DESCRIPTION
Small typo in the README.md since the registry image name is now docker-registry
