### PR TITLE
Replace NotImplemented with NotImplementedError

### DIFF
--- a/lib/storage.py
+++ b/lib/storage.py
@@ -61,28 +61,28 @@ class Storage(object):
                                                   repository)
 
     def get_content(self, path):
-        raise NotImplemented
+        raise NotImplementedError
 
     def put_content(self, path, content):
-        raise NotImplemented
+        raise NotImplementedError
 
     def stream_read(self, path):
-        raise NotImplemented
+        raise NotImplementedError
 
     def stream_write(self, path, fp):
-        raise NotImplemented
+        raise NotImplementedError
 
     def list_directory(self, path=None):
-        raise NotImplemented
+        raise NotImplementedError
 
     def exists(self, path):
-        raise NotImplemented
+        raise NotImplementedError
 
     def remove(self, path):
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_size(self, path):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class LocalStorage(Storage):


### PR DESCRIPTION
[NotImplementedError](http://docs.python.org/2/library/exceptions.html#exceptions.NotImplementedError) is a exception which derives from the `Exception` type and [NotImplemented](http://docs.python.org/2/reference/datamodel.html#the-standard-type-hierarchy) is a type.
