### PR TITLE
Add secret_key to README and config sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ gunicorn --access-logfile - --debug -k gevent -b 0.0.0.0:5000 -w 1 wsgi:applicat
 The recommended setting to run the Registry in a prod environment is gunicorn behind a nginx server which supports
 chunked transfer-encoding (nginx >= 1.3.9).
 
-You could use for instance supervisord to spawn the Registry using this command:
+You could use for instance supervisord to spawn the registry with 8 workers using this command:
 
 ```
 gunicorn -k gevent --max-requests 100 --graceful-timeout 3600 -t 3600 -b localhost:5000 -w 8 wsgi:application
 ```
+
+Note that when using multiple workers, the secret_key for the Flask session must be set explicitly
+in config.yml. Otherwise each worker will use its own random secret key, leading to unpredictable
+behavior.
 
 The nginx configuration will look like:
 

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -18,6 +18,8 @@ prod:
     # to the main Index (https://index.docker.io). Enabling standalone (default)
     # also disables authentication
     standalone: False
+    # The secret key must be set explicitly when using multiple workers.
+    secret_key: REPLACEME
     storage: s3
     storage_path: /prod
     # Enabling this options makes the Registry send an email on each code Exception


### PR DESCRIPTION
The secret_key setting needs to be set in config.yml for most production
environments. Document this in README.md and provide an example in
config_sample.yml.

Fixes #51.
