### PR TITLE
Allow empty list [] in push to /v1/repositories/<path>/

### DIFF
--- a/registry/index.py
+++ b/registry/index.py
@@ -1,4 +1,3 @@
-
 import simplejson as json
 from flask import request
 
@@ -78,7 +77,7 @@ def put_repository(namespace, repository, images=False):
         data = json.loads(request.data)
     except json.JSONDecodeError:
         return api_error('Error Decoding JSON', 400)
-    if not data or not isinstance(data, list):
+    if not isinstance(data, list):
         return api_error('Invalid data')
     update_index_images(namespace, repository, request.data)
     headers = generate_headers(namespace, repository, 'write')


### PR DESCRIPTION
Multiple pushes (with current docker master client) to the same repository path will end up sending PUT [] to /v1/repositories/<path>/.

Currently we api_error 400 in this case, which the docker client doesn't like.

This is already handled properly in update_index_images, so we might as well allow it.
