### PR TITLE
Allow overriding of gunicorn while still preserving env variable injection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN cp --no-clobber /docker-registry/config_sample.yml /docker-registry/config.y
 
 EXPOSE 5000
 
-CMD cd /docker-registry && ./docker-run.sh
+CMD cd /docker-registry && ./setup-configs.sh && gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout 3600 -t 3600 -k gevent -b 0.0.0.0:5000 -w 2 wsgi:application

--- a/setup-configs.sh
+++ b/setup-configs.sh
@@ -13,8 +13,3 @@ if [ "$SETTINGS_FLAVOR" = "prod" ]
 		config=${config//secret_key: REPLACEME/secret_key: $WORKER_SECRET_KEY}; 
 		printf '%s\n' "$config" >config.yml
 fi
-
-gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout 3600 -t 3600 -k gevent -b 0.0.0.0:5000 -w $GUNICORN_WORKERS wsgi:application
-
-
-


### PR DESCRIPTION
A followup to https://github.com/dotcloud/docker-registry/pull/60
