### PR TITLE
Don't set a secret_key in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ADD . /docker-registry
 
 RUN cd /docker-registry && pip install -r requirements.txt
 RUN cp --no-clobber /docker-registry/config_sample.yml /docker-registry/config.yml
-RUN sed -i "s/ secret_key: REPLACEME/ secret_key: $(< /dev/urandom tr -dc A-Za-z0-9 | head -c 32)/" /docker-registry/config.yml
 
 EXPOSE 5000
 

--- a/setup-configs.sh
+++ b/setup-configs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+WORKER_SECRET_KEY="${WORKER_SECRET_KEY:-$(< /dev/urandom tr -dc A-Za-z0-9 | head -c 32)}"
+sed -i "s/ secret_key: REPLACEME/ secret_key: ${WORKER_SECRET_KEY}/" config.yml
+
 if [[ -z "$GUNICORN_WORKERS" ]] ; then
     GUNICORN_WORKERS=4
 fi
@@ -9,6 +12,5 @@ if [ "$SETTINGS_FLAVOR" = "prod" ] ; then
     config=${config//s3_access_key: REPLACEME/s3_access_key: $AWS_ACCESS_KEY_ID};
     config=${config//s3_secret_key: REPLACEME/s3_secret_key: $AWS_SECRET_KEY};
     config=${config//s3_bucket: REPLACEME/s3_bucket: $S3_BUCKET};
-    config=${config//secret_key: REPLACEME/secret_key: $WORKER_SECRET_KEY};
     printf '%s\n' "$config" >config.yml
 fi


### PR DESCRIPTION
Setting the key in the `Dockerfile` means everyone that pulls the
image from the public index gets the same key. This moves the key
generation to the `setup-configs.sh` script.

Let me know if I'm misunderstanding. This will mean the existing image
needs to be regenerated and pushed of course.
