### PR TITLE
Fix for Issue #84:

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ common:
 prod:
     loglevel: warn
     storage: local
-    storage_path: /srv/docker/
+    storage_path: /srv/docker
     smtp_host: localhost
     from_addr: docker@myself.com
     to_addr: my@myself.com
@@ -54,11 +54,11 @@ prod:
 dev:
     loglevel: debug
     storage: local
-    storage_path: /home/myself/docker/
+    storage_path: /home/myself/docker
 
 test:
     storage: local
-    storage_path: /tmp/tmpdockertmp/
+    storage_path: /tmp/tmpdockertmp
 ```    
 
 


### PR DESCRIPTION
Having a trailing slash '/' on the storage path results in the following error:
IOError: [Errno 2] No such file or directory: '/srv/docker/epositories...

While this doesn't solve that problem, it corrects the doco in the meantime.
