### PR TITLE
Add config option for S3 encryption.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ newrelic.ini
 dist
 build
 eggs
+
+Vagrantfile
+.vagrant

--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ to `s3`.
 
 1. `s3_access_key`: string, S3 access key
 1. `s3_secret_key`: string, S3 secret key
-1. `s3_bucket`: string, S3 bucker name
+1. `s3_bucket`: string, S3 bucket name
+1. `s3_encrypt`: boolean, if true, the container will be encrypted on the 
+      server-side by S3 and will be stored in an encrypted form while at rest 
+      in S3.
 
 ### Email options
 

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -4,6 +4,7 @@ common:
     s3_access_key: REPLACEME
     s3_secret_key: REPLACEME
     s3_bucket: REPLACEME
+    s3_encrypt: false
     # Set a random string here
     secret_key: REPLACEME
 
@@ -18,7 +19,7 @@ dev:
 prod:
     storage: s3
     storage_path: /prod
-    # Enabling this options makes the Registry send an email on each code Exception
+    # Enabling these options makes the Registry send an email on each code Exception
     email_exceptions:
         smtp_host: REPLACEME
         smtp_login: REPLACEME

--- a/lib/storage/s3.py
+++ b/lib/storage/s3.py
@@ -51,7 +51,8 @@ class S3Storage(Storage):
     def put_content(self, path, content):
         path = self._init_path(path)
         key = boto.s3.key.Key(self._s3_bucket, path)
-        key.set_contents_from_string(content)
+        key.set_contents_from_string(
+            content, encrypt_key=(self._config.s3_encrypt is True))
         return path
 
     def stream_read(self, path):
@@ -71,7 +72,8 @@ class S3Storage(Storage):
         if self.buffer_size > buffer_size:
             buffer_size = self.buffer_size
         path = self._init_path(path)
-        mp = self._s3_bucket.initiate_multipart_upload(path)
+        mp = self._s3_bucket.initiate_multipart_upload(
+            path, encrypt_key=(self._config.s3_encrypt is True))
         num_part = 1
         while True:
             try:


### PR DESCRIPTION
Adds a configuration option for server-side S3 encryption. It's a fairly dumb method - it just checks the value and, if true, passes the extra parameter that boto is looking for.

Also fixed a typo or two and added documentation to the README.
