### PR TITLE
Introduce Elliptics backend for registry.

### DIFF
--- a/lib/storage/__init__.py
+++ b/lib/storage/__init__.py
@@ -136,7 +136,7 @@ def load(kind=None):
     elif kind == 'glance':
         store = GlanceStorage(cfg)
     elif kind == 'elliptics':
-        from ell import EllipticsStorage
+        from ellipticsbackend import EllipticsStorage
         store = EllipticsStorage(cfg)
     else:
         raise ValueError('Not supported storage \'{0}\''.format(kind))

--- a/lib/storage/ellipticsbackend.py
+++ b/lib/storage/ellipticsbackend.py
@@ -1,5 +1,9 @@
-import os
-import shutil
+"""
+Elliptics is a fault tolerant distributed key/value storage.
+See: http://reverbrain.com/elliptics and
+https://github.com/reverbrain/elliptics
+"""
+
 import itertools
 
 import cache
@@ -37,7 +41,6 @@ class EllipticsStorage(Storage):
         r.wait()
         result = r.get()
         return [i.indexes[0].data for i in itertools.chain(result)]
-        
 
     def s_remove(self, key):
         self._session.remove(key)
@@ -49,7 +52,7 @@ class EllipticsStorage(Storage):
 
     def s_write(self, key, value, tags):
         self._session.write_data(key, str(value)).wait()
-        r = self._session.set_indexes(key, list(tags), [key]*len(tags))
+        r = self._session.set_indexes(key, list(tags), [key] * len(tags))
         r.wait()
         return r.successful()
 
@@ -72,7 +75,7 @@ class EllipticsStorage(Storage):
             _tag = '/'.join(spl_path[:-1])
             spl_path.pop()
             self.s_write(_path, "DIRECTORY", ('docker', _tag))
-        return path        
+        return path
 
     def stream_write(self, path, fp):
         chunks = []


### PR DESCRIPTION
We use a Docker in our open-source PaaS Cocaine (https://github.com/cocaine) in Yandex. Also we use Ellptics as storage in our cloud. So I added support Elliptics as backend for docker-registry.

More info about Elliptics: http://doc.reverbrain.com/elliptics:elliptics https://github.com/reverbrain/elliptics
