### PR TITLE
NGINX CONFIG: enable chunking, point out nginx-extras requirement

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -1,4 +1,6 @@
 # Requires nginx >=1.3.9
+# FYI: Chunking requires nginx-extra package on Debian Wheezy and some Ubuntu versions
+# See chunking http://wiki.nginx.org/HttpChunkinModule
 # Replace with appropriate values where necessary
 
 upstream docker-registry {
@@ -16,7 +18,14 @@ server {
   proxy_set_header Host       $http_host;   # required for docker client's sake
   proxy_set_header X-Real-IP  $remote_addr; # pass on real client's IP
   
-  client_max_body_size 800M; # avoid HTTP 413 for large image uploads
+  client_max_body_size 0; # disable any limits to avoid HTTP 413 for large image uploads
+
+  # required to avoid HTTP 411: see Issue #1486 (https://github.com/dotcloud/docker/issues/1486)
+  chunkin on;
+  error_page 411 = @my_411_error;
+  location @my_411_error {
+    chunkin_resume;
+  }
   
   location / {
     proxy_pass http://docker-registry;


### PR DESCRIPTION
- Take care or ERROR 411, see [Issue #1486](https://github.com/dotcloud/docker/issues/1486). 
  Thanks to @Denmat for pointing this out.
- Remove limits on image size uploads
- Mention nginx-extra requirement for "chunkin" support
