### PR TITLE
storage_path with local and trailing '/', error when parsing path through list_directory

### DIFF
--- a/lib/storage/local.py
+++ b/lib/storage/local.py
@@ -57,8 +57,9 @@ class LocalStorage(Storage):
                     break
 
     def list_directory(self, path=None):
+        prefix = path + '/'
         path = self._init_path(path)
-        prefix = path[len(self._root_path) + 1:] + '/'
+
         exists = False
         for d in os.listdir(path):
             exists = True


### PR DESCRIPTION
To reproduce:

Within your config: `storage: local` and `storage_path: /tmp/repository/`. Note the trailing slash in storage_path.

Navigate to: `HOST/v1/repositories/library/<NAME>/tags`.

The logic error is at `lib/storage/local.py` in `list_directory`.
