### PR TITLE
repository not present in authorization header for standalone registry

### DIFF
--- a/registry/toolkit.py
+++ b/registry/toolkit.py
@@ -234,7 +234,10 @@ def get_repository():
     if not auth:
         return
     auth = dict(_auth_exp.findall(auth))
-    parts = auth.get('repository').rstrip('/').split('/', 1)
+    repository = auth.get('repository')
+    if repository is None:
+        return ('', '')
+    parts = repository.rstrip('/').split('/', 1)
     if len(parts) < 2:
         return ('library', parts[0])
     return (parts[0], parts[1])


### PR DESCRIPTION
In `registry/toolbox.py` within `get_repository` should the `authorization` HTTP request header be present in standalone registries? 

I'm using HTTP Basic Auth and the `authorization` header becomes: "Basic base64(username + ':' + password)", which is normal. I cannot find the logic that conforms to `_auth_exp` and yields a "repository" for the first match in a standalone deployment.

Perhaps for private repositories?

Either way, I'm guessing it's fine to support basic auth without a given repository? In this scenario (when requesting json) `auth.get('repository')` is a NoneType causing an exception.
