### PR TITLE
Add support for config files outside of the source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ Location of the config file
 Specify the config file to be used by setting `DOCKER_REGISTRY_CONFIG` in your 
 environment: `export DOCKER_REGISTRY_CONFIG=config.yml`
 
-The location of the yaml file should be relative to the source directory. 
-Absolute paths are not yet supported.
-
 The default location of the config file is `config.yml`, located in the source 
 directory.
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -52,9 +52,10 @@ def load():
     if _config is not None:
         return _config
     data = None
-    config_file = os.environ.get('DOCKER_REGISTRY_CONFIG', 'config.yml')
-    config_path = os.path.join(os.path.dirname(__file__), '..', 'config',
-                               config_file)
+    config_path = os.environ.get('DOCKER_REGISTRY_CONFIG', 'config.yml')
+    if not os.path.isabs(config_path):
+        config_path = os.path.join(os.path.dirname(__file__), '..',
+                                   'config', config_path)
     with open(config_path) as f:
         data = yaml.load(f)
     config = data.get('common', {})


### PR DESCRIPTION
Config files can be specified now with absolute paths with the `DOCKER_REGISTRY_CONFIG` variable, for example:

```
export DOCKER_REGISTRY_CONFIG=/etc/docker-registry.yml
```

This was initially reported in RH Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1038874
