### PR TITLE
Added support for environment variable default value

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -36,7 +36,6 @@ def convert_env_vars(config):
     def _replace_env(s):
         if isinstance(s, basestring) and s.startswith('_env:'):
             parts = s.split(':', 2)
-            ln = len(parts)
             varname = parts[1]
             vardefault = '!ENV_NOT_FOUND' if len(parts) < 3 else parts[2]
             return os.environ.get(varname, vardefault)


### PR DESCRIPTION
Added support for default env value in the config

For example:

``` yaml
prod:
    secret_key: _env:REGISTRY_SECRET_KEY:foobar_secret
```

Basically, if the environment variable REGISTRY_SECRET_KEY does not exist, it'll be equal to "foobar_secret".

It will deprecate the script setup-configs.sh
