### PR TITLE
Fix Dockerfile for new config locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y git-core python-pip build-essential python-dev libevent1-
 ADD . /docker-registry
 
 RUN cd /docker-registry && pip install -r requirements.txt
-RUN cp --no-clobber /docker-registry/config_sample.yml /docker-registry/config.yml
+RUN cp --no-clobber /docker-registry/config/config_sample.yml /docker-registry/config/config.yml
 
 EXPOSE 5000
 


### PR DESCRIPTION
I ran the Trusted Build service on a fork of `dotcloud:master` but the build failed with
`cp: cannot stat '/docker-registry/config_sample.yml': No such file or directory
Error build: The command [/bin/sh -c cp --no-clobber /docker-registry/config_sample.yml /docker-registry/config.yml] returned a non-zero code: 1`
