### PR TITLE
Configure `prod` storage path via environment variable

### DIFF
--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -33,7 +33,7 @@ dev:
 # $ export SETTINGS_FLAVOR=prod
 prod:
     storage: s3
-    storage_path: /prod
+    storage_path: "_env:STORAGE_PATH:/prod"
     # Enabling LRU cache for small files. This speeds up read/write on small files
     # when using a remote storage backend (like S3).
     cache_lru:


### PR DESCRIPTION
I don't see another way of setting this at run time.
