### PR TITLE
Timeout env vars added to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,13 @@ if [[ -z "$REGISTRY_PORT" ]] ; then
     REGISTRY_PORT=5000
 fi
 
+if [[ -z "$GUNICORN_GRACEFUL_TIMEOUT" ]] ; then
+    GUNICORN_GRACEFUL_TIMEOUT=3600
+fi
+
+if [[ -z "$GUNICORN_SILENT_TIMEOUT" ]] ; then
+    GUNICORN_SILENT_TIMEOUT=3600
+fi
 
 cd "$(dirname $0)"
-gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout 3600 -t 3600 -k gevent -b 0.0.0.0:$REGISTRY_PORT -w $GUNICORN_WORKERS wsgi:application
+gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout $GUNICORN_GRACEFUL_TIMEOUT -t $GUNICORN_SILENT_TIMEOUT -k gevent -b 0.0.0.0:$REGISTRY_PORT -w $GUNICORN_WORKERS wsgi:application


### PR DESCRIPTION
I have large images to push privately which timeout gunicorn, and I run my registry as a docker repo.

Being able to pass in env variables to the docker run will help stability.

Thanks,

Z
