### PR TITLE
Added support for repository/json. Data parsed from the user-agent

### DIFF
--- a/lib/storage/__init__.py
+++ b/lib/storage/__init__.py
@@ -57,6 +57,11 @@ class Storage(object):
                                             repository,
                                             tagname)
 
+    def repository_json_path(self, namespace, repository):
+        return '{0}/{1}/{2}/json'.format(self.repositories,
+                                         namespace,
+                                         repository)
+
     def index_images_path(self, namespace, repository):
         return '{0}/{1}/{2}/_index_images'.format(self.repositories,
                                                   namespace,

--- a/registry/tags.py
+++ b/registry/tags.py
@@ -1,5 +1,8 @@
 
+import datetime
 import logging
+import re
+import time
 
 import flask
 import simplejson as json
@@ -13,6 +16,7 @@ from .app import app
 
 store = storage.load()
 logger = logging.getLogger(__name__)
+RE_USER_AGENT = re.compile('([^\s/]+)/([^\s/]+)')
 
 
 @app.route('/v1/repositories/<path:repository>/properties', methods=['PUT'])
@@ -48,8 +52,7 @@ def get_properties(namespace, repo):
     })
 
 
-@app.route('/v1/repositories/<path:repository>/tags',
-           methods=['GET'])
+@app.route('/v1/repositories/<path:repository>/tags', methods=['GET'])
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 def get_tags(namespace, repository):
@@ -68,8 +71,7 @@ def get_tags(namespace, repository):
     return toolkit.response(data)
 
 
-@app.route('/v1/repositories/<path:repository>/tags/<tag>',
-           methods=['GET'])
+@app.route('/v1/repositories/<path:repository>/tags/<tag>', methods=['GET'])
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 def get_tag(namespace, repository, tag):
@@ -81,6 +83,40 @@ def get_tag(namespace, repository, tag):
     except IOError:
         return toolkit.api_error('Tag not found', 404)
     return toolkit.response(data)
+
+
+@app.route('/v1/repositories/<path:repository>/json', methods=['GET'])
+@toolkit.parse_repository_name
+@toolkit.requires_auth
+def get_repository_json(namespace, repository):
+    json_path = store.repository_json_path(namespace, repository)
+    data = {'last_update': None,
+            'docker_version': None,
+            'docker_go_version': None,
+            'arch': 'amd64',
+            'os': 'linux',
+            'kernel': None}
+    try:
+        data = json.loads(store.get_content(json_path))
+    except IOError:
+        # We ignore the error, we'll serve the default json declared above
+        pass
+    return toolkit.response(data)
+
+
+def create_repository_json(user_agent):
+    props = {
+        'last_update': int(time.mktime(datetime.datetime.utcnow().timetuple()))
+    }
+    ua = dict(RE_USER_AGENT.findall(user_agent))
+    if 'docker' in ua:
+        props['docker_version'] = ua['docker']
+    if 'go' in ua:
+        props['docker_go_version'] = ua['go']
+    for k in ['arch', 'kernel', 'os']:
+        if k in ua:
+            props[k] = ua[k].lower()
+    return json.dumps(props)
 
 
 @app.route('/v1/repositories/<path:repository>/tags/<tag>',
@@ -103,6 +139,12 @@ def put_tag(namespace, repository, tag):
     sender = flask.current_app._get_current_object()
     signals.tag_created.send(sender, namespace=namespace,
                              repository=repository, tag=tag, value=data)
+    if tag == 'latest':
+        # Write some meta-data about the repos
+        ua = flask.request.headers.get('user-agent', '')
+        data = create_repository_json(user_agent=ua)
+        json_path = store.repository_json_path(namespace, repository)
+        store.put_content(json_path, data)
     return toolkit.response()
 
 

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -12,20 +12,42 @@ class TestTags(base.TestCase):
         image_id = self.gen_random_string()
         layer_data = self.gen_random_string(1024)
         self.upload_image(image_id, parent_id=None, layer=layer_data)
+
         # test tags create
         url = '/v1/repositories/foo/{0}/tags/latest'.format(repos_name)
+        headers = {'User-Agent':
+                   'docker/0.7.2-dev go/go1.2 os/ostest arch/archtest'}
         resp = self.http_client.put(url,
+                                    headers=headers,
                                     data=json.dumps(image_id))
         self.assertEqual(resp.status_code, 200, resp.data)
         url = '/v1/repositories/foo/{0}/tags/test'.format(repos_name)
         resp = self.http_client.put(url,
                                     data=json.dumps(image_id))
         self.assertEqual(resp.status_code, 200, resp.data)
+
+        # test tags read
+        url = '/v1/repositories/foo/{0}/tags/latest'.format(repos_name)
+        resp = self.http_client.get(url)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertEqual(json.loads(resp.data), image_id, resp.data)
+
+        # test repository json
+        url = '/v1/repositories/foo/{0}/json'.format(repos_name)
+        resp = self.http_client.get(url)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        props = json.loads(resp.data)
+        self.assertEqual(props['docker_version'], '0.7.2-dev')
+        self.assertEqual(props['docker_go_version'], 'go1.2')
+        self.assertEqual(props['os'], 'ostest')
+        self.assertEqual(props['arch'], 'archtest')
+
         # test tags list
         url = '/v1/repositories/foo/{0}/tags'.format(repos_name)
         resp = self.http_client.get(url)
         self.assertEqual(resp.status_code, 200, resp.data)
         self.assertEqual(len(json.loads(resp.data)), 2, resp.data)
+
         # test tag delete
         url = '/v1/repositories/foo/{0}/tags/latest'.format(repos_name)
         resp = self.http_client.delete(url)
@@ -36,6 +58,7 @@ class TestTags(base.TestCase):
         url = '/v1/repositories/foo/{0}/tags/latest'.format(repos_name)
         resp = self.http_client.get(url)
         self.assertEqual(resp.status_code, 404, resp.data)
+
         # test whole delete
         url = '/v1/repositories/foo/{0}/tags'.format(repos_name)
         resp = self.http_client.delete(url)


### PR DESCRIPTION
This is the first step to add support for arch checking when pulling. It adds 2 things:
1. The user-agent header is parsed when the "latest" tag is set.
2. A new endpoint "repository/foo/bar/json" exposes some new data about the repos.

It's different from the repos properties, those information are "static", not set afterwards. Right now only based from the user-agent but we might want to add some more data later.

I also improve some tags tests (and added the one related to these changes).
