### PR TITLE
Add dockertest including coverage when running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
+# VERSION 0.1
+# DOCKER-VERSION  0.7.3
+# AUTHOR:         Sam Alba <sam@docker.com>
+# DESCRIPTION:    Image with docker-registry project and dependecies
+# TO_BUILD:       docker build -rm -t registry .
+# TO_RUN:         docker run -p 5000:5000 registry
+
 FROM stackbrew/ubuntu:13.04
 
 RUN sed -i 's/main$/main universe/' /etc/apt/sources.list && apt-get update
-RUN apt-get install -y git-core python-pip build-essential python-dev libevent1-dev python-openssl liblzma-dev
+RUN apt-get install -y git-core build-essential python-dev \
+    libevent1-dev python-openssl liblzma-dev wget
+RUN cd /tmp; wget http://python-distribute.org/distribute_setup.py
+RUN cd /tmp; python distribute_setup.py; easy_install pip; \
+    rm distribute_setup.py
 ADD . /docker-registry
 ADD ./config/boto.cfg /etc/boto.cfg
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+coverage==3.6
 hacking==0.7.0
 mock==1.0.1
 -e git+https://github.com/locationlabs/mockredis.git#egg=mockredis

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,19 @@
+# VERSION 0.1
+# DOCKER-VERSION  0.7.3
+# AUTHOR:         Daniel Mizyrycki <daniel@docker.com>
+# DESCRIPTION:    Test image with docker-registry project and dependecies
+# TO_BUILD:       docker build -rm -t docker-registry-test .
+# TO_RUN:         docker run -rm -i -t docker-registry-test
+
+FROM registry
+MAINTAINER Daniel Mizyrycki <daniel@docker.com>
+
+# Add docker-registry testing dependencies
+RUN apt-get install -y --no-install-recommends libssl-dev
+RUN pip install -r /docker-registry/test-requirements.txt
+RUN pip install tox==1.6.1
+
+# Mountpoint used to share coverage results
+RUN mkdir /data
+
+CMD ["sh", "-c", "/docker-registry/test/dockertest.sh"]

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+cat $0
+set -x
+
+# Signal coverage report name, parsed by docker-ci
+COVERAGE_FILE=$(date +"docker-registry-%Y%m%d%H%M%S")
+
+cd /docker-registry
+tox
+exit_status=$?
+if [ "$exit_status" -eq "0" ]; then
+    mv reports /data/$COVERAGE_FILE; fi
+exit $exit_status
+

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ setenv = SETTINGS_FLAVOR=test
          PYTHONPATH=test
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = python -m unittest discover -s {toxinidir}/test {posargs}
+commands = coverage run -m unittest discover -s {toxinidir}/test {posargs}
+           coverage html -d reports --include='./*' --omit='*test*','.tox*'
 
 [testenv:pep8]
 commands = flake8 {toxinidir}


### PR DESCRIPTION
The dockertest here ensures test repeatability as a standalone test container, and simplifying both standalone and continuous integration testing

Note: I had to update /Dockerfile as pip from the ubuntu repository is too old and tox was failing:
Ref: https://bitbucket.org/hpk42/tox/issue/126/tox-fails-with-no-such-option-pre
