### PR TITLE
Added apt package liblzma-dev to satisfy need for lzma headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ is already taken, find out which one has been taken by running "docker ps"
 Install the system requirements for building a Python library:
 
 ```
-sudo apt-get install build-essential python-dev libevent-dev python-pip
+sudo apt-get install build-essential python-dev libevent-dev python-pip liblzma-dev
 ```
 
 Then install the Registry app:


### PR DESCRIPTION
When running "pip install -r requests", one of the pip packages requires the lzma header files which are not present by default.  adding liblzma-dev to the list of apt packages fixes this requirement.
