### PR TITLE
Allow to specify Elliptics namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,34 +127,34 @@ to `s3`.
 These options configure your [Elliptics](http://reverbrain.com/elliptics/) storage. These are used when `storage` is set
 to `elliptics`.
 
-1. `nodes`: Elliptics remotes
-1. `wait-timeout`: time to wait for the operation complete
-1. `check_timeout`: timeout for pinging node
-1. `io-thread-num`: number of IO threads in processing pool
-1. `net-thread-num`: number of threads in network processing pool
-1. `nonblocking_io_thread_num`: number of IO threads in processing pool dedicated to nonblocking ops
-1. `groups`: Elliptics groups registry should use
-1. `verbosity`: Elliptics logger verbosity (0...4)
-1. `logfile`: path to Elliptics logfile (default: `dev/stderr`)
+1. `elliptics_nodes`: Elliptics remotes
+1. `elliptics_wait_timeout`: time to wait for the operation complete
+1. `elliptics_check_timeout`: timeout for pinging node
+1. `elliptics_io_thread_num`: number of IO threads in processing pool
+1. `elliptics_net_thread_num`: number of threads in network processing pool
+1. `elliptics_nonblocking_io_thread_num`: number of IO threads in processing pool dedicated to nonblocking ops
+1. `elliptics_groups`: Elliptics groups registry should use
+1. `elliptics_verbosity`: Elliptics logger verbosity (0...4)
+1. `elliptics_logfile`: path to Elliptics logfile (default: `dev/stderr`)
 
 Example:
 ```yaml
 dev:
   storage: elliptics
-  nodes:
+  elliptics_nodes:
       elliptics-host1: 1025
       elliptics-host2: 1025
       ...
       hostN: port
-  wait-timeout: 60
-  check_timeout: 60
-  io-thread-num: 2
-  net-thread-num: 2
-  nonblocking_io_thread_num: 2
-  groups: [1, 2, 3]
-  verbosity: 4
-  logfile: "/tmp/logfile.log"
-  loglevel: debug
+  elliptics_wait_timeout: 60
+  elliptics_check_timeout: 60
+  elliptics_io_thread_num: 2
+  elliptics_net_thread_num: 2
+  elliptics_nonblocking_io_thread_num: 2
+  elliptics_groups: [1, 2, 3]
+  elliptics_verbosity: 4
+  elliptics_logfile: "/tmp/logfile.log"
+  elliptics_loglevel: debug
 ```
 
 ### Email options

--- a/lib/storage/ellipticsbackend.py
+++ b/lib/storage/ellipticsbackend.py
@@ -27,33 +27,33 @@ class EllipticsStorage(Storage):
     def __init__(self, config):
         cfg = elliptics.Config()
         # The parameter which sets the time to wait for the operation complete
-        cfg.config.wait_timeout = config.get("wait-timeout", 60)
+        cfg.config.wait_timeout = config.get("elliptics_wait_timeout", 60)
         # The parameter which sets the timeout for pinging node
-        cfg.config.check_timeout = config.get("check_timeout", 60)
+        cfg.config.check_timeout = config.get("elliptics_check_timeout", 60)
         # Number of IO threads in processing pool
-        cfg.config.io_thread_num = config.get("io-thread-num", 2)
+        cfg.config.io_thread_num = config.get("elliptics_io_thread_num", 2)
         # Number of threads in network processing pool
-        cfg.config.net_thread_num = config.get("net-thread-num", 2)
+        cfg.config.net_thread_num = config.get("elliptics_net_thread_num", 2)
         # Number of IO threads in processing pool dedicated to nonblocking ops
-        nonblock_io_threads = config.get("nonblocking_io_thread_num", 2)
-        cfg.config.nonblocking_io_thread_num = nonblock_io_threads
-        self.groups = config.get('groups', [])
+        nblock_iothreads = config.get("elliptics_nonblocking_io_thread_num", 2)
+        cfg.config.nonblocking_io_thread_num = nblock_iothreads
+        self.groups = config.get('elliptics_groups', [])
         if len(self.groups) == 0:
             raise ValueError("Specify groups")
 
         # loglevel of elliptics logger
-        elliptics_log_level = config.get('verbosity', 0)
+        elliptics_log_level = config.get('elliptics_verbosity', 0)
 
         # path to logfile
-        elliptics_log_file = config.get('logfile', '/dev/stderr')
+        elliptics_log_file = config.get('elliptics_logfile', '/dev/stderr')
         log = elliptics.Logger(elliptics_log_file, elliptics_log_level)
         self._elliptics_node = elliptics.Node(log, cfg)
 
-        self.namespace = config.get('namespace', DEFAULT_NAMESPACE)
+        self.namespace = config.get('elliptics_namespace', DEFAULT_NAMESPACE)
         logger.info("Using namespace %s", self.namespace)
 
         at_least_one = False
-        for host, port in config.get('nodes').iteritems():
+        for host, port in config.get('elliptics_nodes').iteritems():
             try:
                 self._elliptics_node.add_remote(host, port)
                 at_least_one = True


### PR DESCRIPTION
- `Namespace` option for Elliptics backend. Allow to share one Elliptics installation between registries. It's useful in case of migration from version to version.
- Proper handling of adding remote nodes.
- Check status of all IO operations.
