### PR TITLE
Fix arch update

### DIFF
--- a/lib/storage/__init__.py
+++ b/lib/storage/__init__.py
@@ -67,10 +67,10 @@ class Storage(object):
                                          repository)
 
     def repository_tag_json_path(self, namespace, repository, tag):
-        return '{0}/{1}/{2}/{3}_json'.format(self.repositories,
-                                         namespace,
-                                         repository,
-                                         tag)
+        return '{0}/{1}/{2}/tag{3}_json'.format(self.repositories,
+                                                namespace,
+                                                repository,
+                                                tag)
 
     def index_images_path(self, namespace, repository):
         return '{0}/{1}/{2}/_index_images'.format(self.repositories,

--- a/registry/tags.py
+++ b/registry/tags.py
@@ -85,6 +85,8 @@ def get_tag(namespace, repository, tag):
     return toolkit.response(data)
 
 
+# warning: this endpoint is deprecated in favor of tag-specific json
+# implemented by get_repository_tag_json
 @app.route('/v1/repositories/<path:repository>/json', methods=['GET'])
 @toolkit.parse_repository_name
 @toolkit.requires_auth
@@ -103,7 +105,10 @@ def get_repository_json(namespace, repository):
         pass
     return toolkit.response(data)
 
-@app.route('/v1/repositories/<path:repository>/<tag>/json', methods=['GET'])
+
+@app.route(
+    '/v1/repositories/<path:repository>/tags/<tag>/json',
+    methods=['GET'])
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 def get_repository_tag_json(namespace, repository, tag):
@@ -162,7 +167,7 @@ def put_tag(namespace, repository, tag):
     data = create_tag_json(user_agent=ua)
     json_path = store.repository_tag_json_path(namespace, repository, tag)
     store.put_content(json_path, data)
-    if tag == "latest": # TODO : deprecate this for v2
+    if tag == "latest":  # TODO(dustinlacewell) : deprecate this for v2
         json_path = store.repository_json_path(namespace, repository)
         store.put_content(json_path, data)
     return toolkit.response()

--- a/scripts/diff-worker.py
+++ b/scripts/diff-worker.py
@@ -18,8 +18,12 @@ import storage
 
 store = storage.load()
 
-redis_default_host = os.environ.get('DOCKER_REDIS_1_PORT_6379_TCP_ADDR', '0.0.0.0')
-redis_default_port = int(os.environ.get('DOCKER_REDIS_1_PORT_6379_TCP_PORT', '6379'))
+redis_default_host = os.environ.get(
+    'DOCKER_REDIS_1_PORT_6379_TCP_ADDR',
+    '0.0.0.0')
+redis_default_port = int(os.environ.get(
+    'DOCKER_REDIS_1_PORT_6379_TCP_PORT',
+    '6379'))
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -88,7 +92,6 @@ def handle_request(layer_id, redis_conn):
         log.info("Another worker is processing %s. Skipping." % layer_id)
 
 if __name__ == '__main__':
-    print "WTTTFFFF"
     parser = get_parser()
     options = parser.parse_args()
     redis_conn = get_redis_connection(options)

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -13,7 +13,7 @@ class TestTags(base.TestCase):
         layer_data = self.gen_random_string(1024)
         self.upload_image(image_id, parent_id=None, layer=layer_data)
 
-        # test tags create
+       # test tags create
         url = '/v1/repositories/foo/{0}/tags/latest'.format(repos_name)
         headers = {'User-Agent':
                    'docker/0.7.2-dev go/go1.2 os/ostest arch/archtest'}
@@ -41,6 +41,50 @@ class TestTags(base.TestCase):
         self.assertEqual(props['docker_go_version'], 'go1.2')
         self.assertEqual(props['os'], 'ostest')
         self.assertEqual(props['arch'], 'archtest')
+
+        # test repository tags json
+        url = '/v1/repositories/foo/{0}/tags/latest/json'.format(repos_name)
+        resp = self.http_client.get(url)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        props = json.loads(resp.data)
+        self.assertEqual(props['docker_version'], '0.7.2-dev')
+        self.assertEqual(props['docker_go_version'], 'go1.2')
+        self.assertEqual(props['os'], 'ostest')
+        self.assertEqual(props['arch'], 'archtest')
+
+       # test tags update
+        url = '/v1/repositories/foo/{0}/tags/latest'.format(repos_name)
+        headers = {'User-Agent':
+                   'docker/0.7.2-dev go/go1.2 os/ostest arch/changedarch'}
+        resp = self.http_client.put(url,
+                                    headers=headers,
+                                    data=json.dumps(image_id))
+        self.assertEqual(resp.status_code, 200, resp.data)
+        url = '/v1/repositories/foo/{0}/tags/test'.format(repos_name)
+        resp = self.http_client.put(url,
+                                    headers=headers,
+                                    data=json.dumps(image_id))
+        self.assertEqual(resp.status_code, 200, resp.data)
+
+        # test repository latest tag json update
+        url = '/v1/repositories/foo/{0}/tags/latest/json'.format(repos_name)
+        resp = self.http_client.get(url)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        props = json.loads(resp.data)
+        self.assertEqual(props['docker_version'], '0.7.2-dev')
+        self.assertEqual(props['docker_go_version'], 'go1.2')
+        self.assertEqual(props['os'], 'ostest')
+        self.assertEqual(props['arch'], 'changedarch')
+
+        # test repository test tag json update
+        url = '/v1/repositories/foo/{0}/tags/test/json'.format(repos_name)
+        resp = self.http_client.get(url)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        props = json.loads(resp.data)
+        self.assertEqual(props['docker_version'], '0.7.2-dev')
+        self.assertEqual(props['docker_go_version'], 'go1.2')
+        self.assertEqual(props['os'], 'ostest')
+        self.assertEqual(props['arch'], 'changedarch')
 
         # test tags list
         url = '/v1/repositories/foo/{0}/tags'.format(repos_name)


### PR DESCRIPTION
This adds a new endpoint:

'/v1/repositories/path:repository/tags/<tag>/json'

Which allows you to fetch json for a specific tag. The registry has been updated to save and update json details for every individual tag and this new endpoint is how it can be fetched.

We will still continue to support the repository-level json, which will be a duplicated set of the "latest" tag's json data. 
