### PR TITLE
Dockerfile: clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@
 # TO_BUILD:       docker build -rm -t registry .
 # TO_RUN:         docker run -p 5000:5000 registry
 
-FROM stackbrew/ubuntu:13.04
+FROM ubuntu:13.04
 
-RUN sed -i 's/main$/main universe/' /etc/apt/sources.list && apt-get update
-RUN apt-get install -y git-core build-essential python-dev \
-    libevent1-dev python-openssl liblzma-dev wget
+RUN apt-get update; \
+    apt-get install -y git-core build-essential python-dev \
+    libevent1-dev python-openssl liblzma-dev wget; \
+    rm /var/lib/apt/lists/*_*
 RUN cd /tmp; wget http://python-distribute.org/distribute_setup.py
 RUN cd /tmp; python distribute_setup.py; easy_install pip; \
     rm distribute_setup.py


### PR DESCRIPTION
This changes the Dockerfile to make the following improvements:
- switch to the unprefixed ubuntu image
- stop adding the universe repo
  it's already in the latest stackbrew/ubuntu images by default
- merge the apt-get update and install operations
- remove the package lists in the same apt-get update & install step

These changes reduce the image size reported by `docker images` from 432 MB to 399 MB and gets rid of one layer.
