### PR TITLE
Corrected package name for nginx-extras in nginx.conf

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -1,5 +1,5 @@
 # Requires nginx >=1.3.9
-# FYI: Chunking requires nginx-extra package on Debian Wheezy and some Ubuntu versions
+# FYI: Chunking requires nginx-extras package on Debian Wheezy and some Ubuntu versions
 # See chunking http://wiki.nginx.org/HttpChunkinModule
 # Replace with appropriate values where necessary
 


### PR DESCRIPTION
I found that in the nginx sample file the package nginx-extras was not referred correctly so fixed it. 
