### PR TITLE
Cannot push centos image to registry: Broken Pipe

### DIFF
--- a/lib/storage/glance.py
+++ b/lib/storage/glance.py
@@ -41,7 +41,13 @@ class GlanceStorage(object):
         elif len(args) > 0 and isinstance(args[0], basestring):
             path = args[0]
         if path.startswith(Storage.images):
-            obj = self._storage_layers
+            # The metadata is to huge as it can be
+            # uploaded to glance (broken pipe).
+            # Lets store it in the tags repository
+            if path.endswith("_files"):
+                obj = self._storage_tags
+            else:
+                obj = self._storage_layers
         elif path.startswith(Storage.repositories):
             obj = self._storage_tags
         else:


### PR DESCRIPTION
The metadata of the jar content "_files"  is to huge to to store it in glance
as property since it contains every file of the uploaded TAR.

The problem can be simple solved using the storage_alternate.

fixes #235
