### PR TITLE
Workaround headers too large problem with Glance v1 api

### DIFF
--- a/lib/storage/glance.py
+++ b/lib/storage/glance.py
@@ -194,6 +194,8 @@ class GlanceStorageLayers(Storage):
         (image, propname) = self._init_path(path)
         if not propname:
             raise ValueError('Wrong call (should be stream_write)')
+        if 'meta__files' in propname:
+            return
         props = {propname: content}
         image.update(properties=props, purge_props=False)
 


### PR DESCRIPTION
The files property is too large to fit into HTTP headers so we must drop it with the Glance v1 storage backend. Once we move to Glance v2, we can restore this.
