### PR TITLE
Use exec to eliminate extra shell processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN cp --no-clobber /docker-registry/config/config_sample.yml /docker-registry/c
 
 EXPOSE 5000
 
-CMD cd /docker-registry && ./setup-configs.sh && ./run.sh
+CMD cd /docker-registry && ./setup-configs.sh && exec ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ GUNICORN_GRACEFUL_TIMEOUT=${GUNICORN_GRACEFUL_TIMEOUT:-3600}
 GUNICORN_SILENT_TIMEOUT=${GUNICORN_SILENT_TIMEOUT:-3600}
 
 cd "$(dirname $0)"
-gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout $GUNICORN_GRACEFUL_TIMEOUT -t $GUNICORN_SILENT_TIMEOUT -k gevent -b 0.0.0.0:$REGISTRY_PORT -w $GUNICORN_WORKERS wsgi:application
+exec gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout $GUNICORN_GRACEFUL_TIMEOUT -t $GUNICORN_SILENT_TIMEOUT -k gevent -b 0.0.0.0:$REGISTRY_PORT -w $GUNICORN_WORKERS wsgi:application


### PR DESCRIPTION
The `CMD` `sh -c` and and `run.sh` processes were hanging around in the process tree when the container is started. This isn't a problem as such, but is unnecessary. Add `exec` in the `CMD` call to `run.sh`, and in the start of `gunicorn` within `run.sh` to avoid this.
