### PR TITLE
index: Whitelist 'id' and 'checksum' keys for image data

### DIFF
--- a/registry/index.py
+++ b/registry/index.py
@@ -59,7 +59,11 @@ def update_index_images(namespace, repository, data):
             iid = i['id']
             if iid in images and 'checksum' in images[iid]:
                 continue
-            images[iid] = i
+            i_data = {'id': iid}
+            for key in ['checksum']:
+                if key in i:
+                    i_data[key] = i[key]
+            images[iid] = i_data
         data = images.values()
         store.put_content(path, json.dumps(data))
     except IOError:


### PR DESCRIPTION
The image data behind the "repository images" endpoints is documented as only
having these two keys [1](http://docs.docker.io/en/latest/reference/api/index_api/#repository-images), but on my existing docker-registry instance, I see
additional keys:

```
# cat /var/lib/docker-registry/repositories/wking/gentoo/_index_images  | jq .
[
  {
    "id": "9917ba282bd23e78d1caa25aac74fb9d5d305aee10db0ef84f3230ef7fc93c59",
    "Tag": "latest"
  }
]
```

Instead of storing any image-specific data that the user sends up, this commit
restricts the set of allowed keys.  This avoids interfering with the
Server.pullRepository code in the Docker source, which uses the presence of
img.Tag to decide whether or not to download the image [2](https://github.com/dotcloud/docker/blob/v0.8.1/server.go#L1179).  It also avoids
trouble with the Docker server trying to store auxiliary tags in the
hard-coded ImgData struct [3](https://github.com/dotcloud/docker/blob/v0.8.1/registry/registry.go#L673). The drawback to this extra protection against
over-eager clients pushing undocumented keys is that we'll have to update the
whitelist if new keys are added to ImgData.  This commit also doesn't cull 
undocumented keys from existing image index files.  Folks with existing
registries can use jq [4](http://stedolan.github.io/jq/) to remove them by hand.  In POSIX shell:

```
JQ='[.[] | {"id": .id, "checksum": .checksum}] | del(.[][] | select(. == null))'
for FILE in $(find /var/lib/docker-registry/repositories/ -name _index_images)
do
  FILTERED=$(jq "${JQ}" < "${FILE}")
  echo "${FILTERED}" > "${FILE}"
done
```
