### PR TITLE
images: catch unicode errors

### DIFF
--- a/registry/images.py
+++ b/registry/images.py
@@ -193,7 +193,7 @@ def put_image_layer(image_id):
             tarsum.append(member, tar)
             tarfilesinfo.append(member)
         layers.set_image_files_cache(image_id, tarfilesinfo.json())
-    except (IOError, tarfile.TarError) as e:
+    except (IOError, tarfile.TarError, UnicodeDecodeError) as e:
         logger.debug('put_image_layer: Error when reading Tar stream tarsum. '
                      'Disabling TarSum, TarFilesInfo. Error: {0}'.format(e))
     finally:


### PR DESCRIPTION
When the headers of the TarFile have non-utf8 encoded values (such is
the case for some xattrs for file capabilities) (see
http://ur1.ca/gzn2m), the repository fails to get pushed. Instead, just
do not generate the tarsum for images with this failure.

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
