### PR TITLE
Bump Dockerfile to Saucy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # TO_BUILD:       docker build -rm -t registry .
 # TO_RUN:         docker run -p 5000:5000 registry
 
-FROM ubuntu:13.04
+FROM ubuntu:13:10
 
 RUN apt-get update; \
     apt-get install -y git-core build-essential python-dev \


### PR DESCRIPTION
This replacing the EOL Raring install with the
still-yet-supported Saucy release. Saucy is supported
through to July.

This patch addresses the SSL heartbleed vulnerability.
