### PR TITLE
adding an AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,75 @@
+# This file lists all individuals having contributed content to the repository.
+# If you're submitting a patch, please add your name here in alphabetical order
+# as part of the patch.
+
+Allard Hoeve <allard@byte.nl>
+Anastas Semenov <anapsix@random.io>
+Anastas Semenov <asemenov@chitika.com>
+Andrew Williams <awilliams@intoxitrack.net>
+avaer <avaer@users.noreply.github.com>
+Brad Ison <bison@garbagebrain.org>
+Brendan Burns <bburns@google.com>
+Chas Ballew <chas.ballew@gmail.com>
+Chris Tierney <notproperlycut@gmail.com>
+Christophe Furmaniak <christophe.furmaniak@gmail.com>
+Dan Trujillo <dtrupenn@gmail.com>
+Daniel Graña <dangra@gmail.com>
+Daniel Kuffner <dkuffner@chilicat.net>
+Daniel Mizyrycki <mzdaniel@glidelink.net>
+David Hoyt <dhoyt@hoytsoft.org>
+DenMat <DenMat tu2Bgone@gmail.com>
+Derek McGowan <derek@mcgstyle.net>
+Dr Nic Williams <drnicwilliams@gmail.com>
+Dustin Lacewell <dlacewell@gmail.com>
+Ekaterina Volkova <gloom@google.com>
+Endre Karlson <endre.karlson@gmail.com>
+Eric Windisch <ewindisch@docker.com>
+Eunchong Yu <kroisse@gmail.com>
+Evan Hazlett <ejhazlett@gmail.com>
+fbvs <franciscovieirasantos@gmail.com>
+Flavio Castelli <fcastelli@suse.com>
+Gabe Rosenhouse <gabe@missionst.com>
+Greg Weber <greg@gregweber.info>
+Ian Miell <ian.miell@openbet.com>
+Ilya Rusalowski <rivik@yandex-team.ru>
+James Carr <james.r.carr@gmail.com>
+James Turnbull <james@lovedthanlost.net>
+Jason Sommer <gatoralli69@gmail.com>
+Jigish Patel <jigish@ooyala.com>
+Joffrey F <f.joffrey@gmail.com>
+Johan Euphrosine <proppy@google.com>
+Johnny Tan <johnnydtan@gmail.com>
+Jonas Finnemann Jensen <jopsen@gmail.com>
+jschneiderhan <jon-erik.schneiderhan@meyouhealth.com>
+Ken Cochrane <kencochrane@gmail.com>
+Kevin Clark <kevinc@greplin.com>
+Leon Xiang <leon.xiang@rea-group.com>
+Lucas Clemente <github@clemente.io>
+Marc Tamsky <mtamsky@gmail.com>
+Marek Goldmann <marek.goldmann@gmail.com>
+Mario Rodas <rodasmario2@gmail.com>
+Matthew Fisher <matthewf@activestate.com>
+Michael Hrivnak <mhrivnak@redhat.com>
+Michael Merickel <michael@merickel.org>
+Michael Neale <michael.neale@gmail.com>
+noxiouz <noxiouz@yandex.ru>
+Paul Durivage <pauldurivage@gmail.com>
+Phil Kates <me@philkates.com>
+Raman Gupta <raman@vivosys.com>
+Roberto Aguilar <roberto@baremetal.io>
+Roberto Gandolfo Hashioka <roberto_hashioka@hotmail.com>
+Rohan Singh <rohan@spotify.com>
+Russell Smith <russ@rainforestqa.com>
+Rusty Ross <consultant@rustyross.com>
+Sam Alba <sam.alba@gmail.com>
+Shreyas Karnik <karnik.shreyas@gmail.com>
+Sridatta Thatipamala <sthatipamala@gmail.com>
+Sridhar Ratnakumar <sridharr@activestate.com>
+Stefan Novak <stefan.louis.novak@gmail.com>
+Teddy Reed <teddy@prosauce.org>
+Thomas Frössman <thomasf@jossystem.se>
+Tobias Schwab <tobias.schwab@dynport.de>
+unclejack <unclejacksons@gmail.com>
+Vincent Batts <vbatts@redhat.com>
+W. Trevor King <wking@tremily.us>
+Walter Huf <walter.huf@corvisa.com>


### PR DESCRIPTION
This is the product of `git log --format='%aN <%aE>' | sort -f | uniq > AUTHORS`
plus some cleanup to remove duplicates and noise.

The main docker repo has an AUTHORS file, so I thought it would be nice to have one here as well.
