### PR TITLE
Fix issue #333 - Added CORS support to 'get images' and 'search' methods in registry REST api

### DIFF
--- a/docker_registry/index.py
+++ b/docker_registry/index.py
@@ -1,6 +1,7 @@
 import logging
 
 import flask
+import flask_cors
 import simplejson as json
 
 from . import storage
@@ -106,6 +107,7 @@ def put_repository(namespace, repository, images=False):
 
 
 @app.route('/v1/repositories/<path:repository>/images', methods=['GET'])
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 @mirroring.source_lookup(index_route=True)

--- a/docker_registry/search.py
+++ b/docker_registry/search.py
@@ -1,4 +1,5 @@
 import flask
+import flask_cors
 
 from .lib import config
 from .lib import index
@@ -17,6 +18,7 @@ else:
 
 
 @app.route('/v1/search', methods=['GET'])
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 def get_search():
     search_term = flask.request.args.get('q', '')
     if INDEX is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto==2.27.0
 backports.lzma==0.0.2
 Flask==0.9
+Flask-cors==1.3.0
 PyYAML==3.10
 simplejson==3.1.3
 requests==1.2.0


### PR DESCRIPTION
This change uses flask_cors lib that adds CORS (Cross-Origin Resource Sharing) support to the following 2 REST api methods of docker-registry: search and 'get images'.

Since those are a GET (read) methods, that are public anyway, the added configuration is (*) - all origins are allowed to retrieve that information.
If someone needs to restrict that access, it can be done by changing configuration (CORS_ORIGINS) as described in flask_cors documentation:
http://flask-cors.readthedocs.org/en/latest/#application-wide-settings

This patch is needed because otherwise some integrations with docker that are made with Ajax will become very problematic due to cross origin limitations, and since the registry is also lacking JSONP support which is another method to solve cross origin issues.

More registry's REST methods can also be enabled for CORS in the future by adding @flask_cors.cross_origin on the relevant methods.
