### PR TITLE
Add CORS support to GET repositories/<path:repository>/tags REST api

### DIFF
--- a/docker_registry/tags.py
+++ b/docker_registry/tags.py
@@ -5,6 +5,7 @@ import re
 import time
 
 import flask
+import flask_cors
 import simplejson as json
 
 from . import storage
@@ -64,6 +65,7 @@ def get_tags(namespace, repository):
 
 
 @app.route('/v1/repositories/<path:repository>/tags', methods=['GET'])
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 @mirroring.source_lookup_tag


### PR DESCRIPTION
An addition to #338 - add CORS support to the GET tags method in registry REST api
