### PR TITLE
Fix #248

### DIFF
--- a/docker_registry/lib/layers.py
+++ b/docker_registry/lib/layers.py
@@ -49,6 +49,7 @@ class Archive(lzma.LZMAFile):
     This class wraps a file-object that contains tar archive data. The data
     will be optionally decompressed with lzma/xz if found to be a compressed
     archive.
+    The file-object itself must be seekable.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
@shin- @samalba @wking your thorough review appreciated here, as this is tricky.

What happens (IMO) is that, when fed to tarfile, we first try to read the underlying stream as LZMA. If that fails, possibly a part of that underlying stream is consumed, making it (possibly) impossible to read afterwards, depending at what point we stopped.

What is sure:
- the initial (test_layer) issue crashes here
- this patch (apparently) fix the test on a significant enough number of runs
- the reason why it is random kind of make sense (LZMA might stop reading early, and in some cases, tarfile manages to read, all that depending highly on the content)
- it's hard for me to tell if it has an impact or not outside of the testscases - but if it does, it's a sneaky bug that might pop depending on seemingly random conditions (eg: layer content) 

Now, what about #310 ? Can this be related?
