### PR TITLE
tarsum: include xattr headers in to the checksum

### DIFF
--- a/docker_registry/lib/checksums.py
+++ b/docker_registry/lib/checksums.py
@@ -23,7 +23,9 @@ def sha256_file(fp, data=None):
 def sha256_string(s):
     return hashlib.sha256(s).hexdigest()
 
+
 xattrPaxPrefix = 'SCHILY.xattr.'
+
 
 class TarSum(object):
 


### PR DESCRIPTION
this is to enhance the tarsum algorithm, but _MUST_ be done in lock step
with the same for docker. (PR https://github.com/dotcloud/docker/pull/5977)

Also, this python implementation depends on https://github.com/dotcloud/docker-registry/pull/381

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
