### PR TITLE
Don't crash on Cloudfront IOError

### DIFF
--- a/docker_registry/images.py
+++ b/docker_registry/images.py
@@ -78,9 +78,12 @@ def _get_image_layer(image_id, headers=None, bytes_range=None):
     # If store allows us to just redirect the client let's do that, we'll
     # offload a lot of expensive I/O and get faster I/O
     if cfg.storage_redirect:
-        content_redirect_url = store.content_redirect_url(path)
-        if content_redirect_url:
-            return flask.redirect(content_redirect_url, 302)
+        try:
+            content_redirect_url = store.content_redirect_url(path)
+            if content_redirect_url:
+                return flask.redirect(content_redirect_url, 302)
+        except IOError as e:
+            logger.debug(str(e))
 
     status = None
     layer_size = 0


### PR DESCRIPTION
Catch, log and pass. If it's a genuine FileNotFound, the subsequent code will take care of it
