### PR TITLE
Avoid crashing if storage redirect is enabled with S3 and there is no Cloudfront configured

### DIFF
--- a/docker_registry/drivers/s3.py
+++ b/docker_registry/drivers/s3.py
@@ -72,14 +72,6 @@ class Storage(coreboto.Base):
 
     def makeConnection(self):
         kwargs = self._build_connection_params()
-        if self._config.s3_region is not None:
-            return boto.s3.connect_to_region(
-                region_name=self._config.s3_region,
-                aws_access_key_id=self._config.s3_access_key,
-                aws_secret_access_key=self._config.s3_secret_key,
-                **kwargs)
-        logger.warn("No S3 region specified, using boto default region, " +
-                    "this may affect performance and stability.")
         # Connect cloudfront if we are required to
         if self._config.cloudfront:
             self.signer = Cloudfront(
@@ -89,6 +81,17 @@ class Storage(coreboto.Base):
                 self._config.cloudfront['keyid'],
                 self._config.cloudfront['keysecret']
             ).sign
+        else:
+            self.signer = None
+
+        if self._config.s3_region is not None:
+            return boto.s3.connect_to_region(
+                region_name=self._config.s3_region,
+                aws_access_key_id=self._config.s3_access_key,
+                aws_secret_access_key=self._config.s3_secret_key,
+                **kwargs)
+        logger.warn("No S3 region specified, using boto default region, " +
+                    "this may affect performance and stability.")
 
         return boto.s3.connection.S3Connection(
             self._config.s3_access_key,


### PR DESCRIPTION
Small fix if using S3 storage backend and `storage_redirect: True`.

Avoids exception:

```
Stacktrace (most recent call last):

  File "flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "newrelic/hooks/framework_flask.py", line 86, in wrapper_Flask_handle_exception
    return wrapped(*args, **kwargs)
  File "flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "newrelic/hooks/framework_flask.py", line 40, in handler_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/toolkit.py", line 269, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 35, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 56, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/lib/mirroring.py", line 128, in wrapper
    resp = f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 207, in get_image_layer
    return _get_image_layer(image_id, headers, bytes_range)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 82, in _get_image_layer
    content_redirect_url = store.content_redirect_url(path)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/drivers/s3.py", line 138, in content_redirect_url
    if not self.signer:
'Storage' object has no attribute 'signer'
```
