### PR TITLE
Set standalone to true explicitly in config_sample.yml

### DIFF
--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -3,7 +3,7 @@
 common:
     loglevel: _env:LOGLEVEL:debug
     storage_redirect: _env:STORAGE_REDIRECT
-    standalone: _env:STANDALONE
+    standalone: true
     index_endpoint: _env:INDEX_ENDPOINT
     disable_token_auth: _env:DISABLE_TOKEN_AUTH
     privileged_key: _env:PRIVILEGED_KEY


### PR DESCRIPTION
Setting environment variable STANDALONE to true results in a string
value for cfg.standalone, which fails "cfg.standalone is True" condition.
