### PR TITLE
fix flask raise ValueError when mirroring

### DIFF
--- a/docker_registry/lib/mirroring.py
+++ b/docker_registry/lib/mirroring.py
@@ -195,7 +195,7 @@ def _handle_mirrored_layer(source_resp, layer_path, store, headers):
         tmp.seek(0)
         store.stream_write(layer_path, tmp)
         tmp.close()
-    return flask.Response(generate(), headers=headers)
+    return flask.Response(generate(), headers=dict(headers))
 
 
 def store_mirrored_data(data, endpoint, args, store):


### PR DESCRIPTION
when i setup docker-registry as a image server which mirroring to index.docker.io, and i run `docker pull myserver:5000/nginx`

``` python
2014-07-01 00:05:18,370 ERROR: Exception on /v1/images/842b5a724d2d1d2e554b11a44ec0933dd4531d9f69e09707f239662af442f058/layer [HEAD]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/toolkit.py", line 264, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 35, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/images.py", line 56, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/lib/mirroring.py", line 170, in wrapper
    headers)
  File "/usr/local/lib/python2.7/dist-packages/docker_registry/lib/mirroring.py", line 189, in _handle_mirrored_layer
    return flask.Response(generate(), headers=headers)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/wrappers.py", line 743, in __init__
    self.headers = Headers(headers)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/datastructures.py", line 881, in __init__
    self.extend(defaults)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/datastructures.py", line 1012, in extend
    for key, value in iterable:
ValueError: too many values to unpack
```

the code of `Headers` in flask is

``` python
    def extend(self, iterable):
        """Extend the headers with a dict or an iterable yielding keys and
        values.
        """
        if isinstance(iterable, dict):
            for key, value in iteritems(iterable):
                if isinstance(value, (tuple, list)):
                    for v in value:
                        self.add(key, v)
                else:
                    self.add(key, value)
        else:
            for key, value in iterable:
                self.add(key, value)
```

but header from `return flask.Response(generate(), headers=headers)` in `docker-registry` is not a strict `dict` (`requests.structures.CaseInsensitiveDict` actually)
