### PR TITLE
Fix Redis LRU cache default configuration backwards compatibility

### DIFF
--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -23,20 +23,20 @@ common: &common
         source_index: _env:MIRROR_SOURCE_INDEX # https://index.docker.io
         tags_cache_ttl: _env:MIRROR_TAGS_CACHE_TTL:172800 # seconds
 
-    # cache:
-    #     host: _env:CACHE_REDIS_HOST:localhost
-    #     port: _env:CACHE_REDIS_PORT:6379
-    #     db: 0
-    #     password: _env:CACHE_REDIS_PASSWORD
+    cache:
+        host: _env:CACHE_REDIS_HOST
+        port: _env:CACHE_REDIS_PORT
+        db: _env:CACHE_REDIS_DB:0
+        password: _env:CACHE_REDIS_PASSWORD
 
     # Enabling LRU cache for small files
     # This speeds up read/write on small files
     # when using a remote storage backend (like S3).
-    # cache_lru:
-    #     host: _env:CACHE_LRU_REDIS_HOST:localhost
-    #     port: _env:CACHE_LRU_REDIS_PORT:6379
-    #     db: 0
-    #     password: _env:CACHE_LRU_REDIS_PASSWORD
+    cache_lru:
+        host: _env:CACHE_LRU_REDIS_HOST
+        port: _env:CACHE_LRU_REDIS_PORT
+        db: _env:CACHE_LRU_REDIS_DB:0
+        password: _env:CACHE_LRU_REDIS_PASSWORD
 
     # Enabling these options makes the Registry send an email on each code Exception
     email_exceptions:


### PR DESCRIPTION
Hi, 

   I found this issue when configuring a production registry based on docker image 0.7.3. The current master sample_config.yml might cause compatibility issue when this branch is released.

   The Redis cache YAML configuration should be left undefined value by default.

   Based on [cache.py line 40](https://github.com/dotcloud/docker-registry/blob/d69590228b03b4d54a871bda2a7557d3298c7528/docker_registry/lib/cache.py#L40), the cache is enabled when host is defined. 

   I think the issue was introduced in commit https://github.com/dotcloud/docker-registry/commit/713d7bc72879f38e88d7859a8c5c7ea46099b5b9 with default redis information added.
   Then it was incorrectly patched by commenting out the configuration to fix travis test in commit https://github.com/dotcloud/docker-registry/commit/e014c53ed3c329fa46300b37311672871aef1f48

   I also added two environment variables `CACHE_REDIS_DB` and `CACHE_LRU_REDIS_DB`
