### PR TITLE
Allow S3 host, port, calling format to be specified to enable S3-compatible backends, such as Riak CS

### DIFF
--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -68,6 +68,10 @@ s3: &s3
     s3_secure: _env:AWS_SECURE:true
     s3_access_key: _env:AWS_KEY
     s3_secret_key: _env:AWS_SECRET
+    boto_host: _env:BOTO_HOST
+    boto_port: _env:BOTO_PORT
+    boto_debug: _env:BOTO_DEBUG
+    boto_calling_format: _env:BOTO_CALLING_FORMAT
 
 # Google Cloud Storage Configuration
 # See:

--- a/depends/docker-registry-core/docker_registry/core/boto.py
+++ b/depends/docker-registry-core/docker_registry/core/boto.py
@@ -140,7 +140,8 @@ class Base(driver.Base):
         config_args = [
             'host', 'port', 'debug',
             'proxy', 'proxy_port',
-            'proxy_user', 'proxy_pass'
+            'proxy_user', 'proxy_pass',
+            'calling_format'
         ]
         for arg in config_args:
             confkey = 'boto_' + arg


### PR DESCRIPTION
This adds S3_HOST, S3_PORT, S3_CALLING_FORMAT env vars to be passed through to boto's [S3Connection](http://boto.readthedocs.org/en/latest/ref/s3.html#boto.s3.connection.S3Connection) constructor.

S3_CALLING_FORMAT takes a boto CallingFormat class as a string, such as ["boto.s3.connection.OrdinaryCallingFormat"](http://boto.readthedocs.org/en/latest/ref/s3.html?highlight=callingformat#boto.s3.connection.OrdinaryCallingFormat).

This allows connection to any S3-compatible backend, such as Riak CS.

Also adds a BOTO_DEBUG env var to allow setting the [Boto log level](http://boto.readthedocs.org/en/latest/boto_config_tut.html#boto).

Tested by building docker-registry image and deploying against a Riak CS backend using the [hectcastro/riak-cs](https://registry.hub.docker.com/u/hectcastro/riak-cs/) image.

**Why?**
My experience with setting up object store backends was zero prior to today. I started with Swift, and I did not find any Docker images that appeared to be fully-baked. The complexity and dependencies of Swift discouraged me from making my own image. Moving on to Riak CS, I located the [riak-cs](https://registry.hub.docker.com/u/hectcastro/riak-cs/) image put together by a Basho engineer. I have found it to be functional and well-documented.

This seems like an easy and elegant solution for those looking to hook up a Docker registry to an open source distributed object store.
