### PR TITLE
README.md: Restore SQLAlchemy docs and links

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -103,11 +103,3 @@ Pretty much:
 
 Drivers are expected to receive bytes and to return bytes.
 Don't try to decode or encode content.
-
-## API documentation
-
-[search-endpoint]:
-  http://docs.docker.io/en/latest/reference/api/index_api/#get--v1-search
-[SQLAlchemy]: http://docs.sqlalchemy.org/
-[create_engine]:
-  http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ returns empty results.
    Currently supported backends are:
    1. `sqlalchemy`
 
-
 If `search_backend` is neither empty nor one of the supported backends, it
 should point to a module.
 
@@ -222,7 +221,10 @@ common:
 
 #### sqlalchemy
 
-1. `sqlalchemy_index_database`: The database URL
+Use [SQLAlchemy][] as the search backend.
+
+1. `sqlalchemy_index_database`: The database URL passed through to
+   [create_engine][].
 
 Example:
 
@@ -231,7 +233,6 @@ common:
   search_backend: sqlalchemy
   sqlalchemy_index_database: sqlite:////tmp/docker-registry.db
 ```
-
 
 In this case, the module is imported, and an instance of it's `Index`
 class is used as the search backend.
@@ -494,3 +495,8 @@ For developers
 --------------
 
 Read CONTRIBUTE.md
+
+[search-endpoint]: http://docs.docker.com/reference/api/docker-io_api/#search
+[SQLAlchemy]: http://docs.sqlalchemy.org/
+[create_engine]:
+  http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine


### PR DESCRIPTION
The explanation for sqlalchemy_index_database was removed in bb69c43f
(update documentation for config_sample.yml changes, 2014-05-14), and
the reference URL for search-endpoint was removed in 4ba12e5d (Updated
documentation for 0.7, new developer (contribute) doc, new changelog
file, 2014-05-20).

Since I added the links in fab832bf (search: Use SQLAlchemy as a
search-index backend, 2014-02-12), the search-endpoint URL has moved
from:

  http://docs.docker.io/en/latest/reference/api/index_api/#get--v1-search

to:

  http://docs.docker.com/reference/api/docker-io_api/#search

But I haven't tracked down the Docker-side commit responsible for that
move.
