### PR TITLE
docker_registry.app: Add a /_versions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ When using the `config_sample.yml`, you can pass all options through as environm
 1. `loglevel`: string, level of debugging. Any of python's
    [logging](http://docs.python.org/2/library/logging.html) module levels:
    `debug`, `info`, `warn`, `error` or `critical`
+1. `debug_versions`: boolean, enable the `/_versions` endpoint for debugging.
 1. `storage_redirect`: Redirect resource requested if storage engine supports
    this, e.g. S3 will redirect signed URLs, this can be used to offload the
    server.

--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -2,6 +2,8 @@
 common: &common
     # Default log level is info
     loglevel: _env:LOGLEVEL:info
+    # Enable the debugging /_versions endpoint
+    debug_versions: _env:DEBUG_VERSIONS:false
     # By default, the registry acts standalone (eg: doesn't query the index)
     standalone: _env:STANDALONE:true
     # The default endpoint to use (if NOT standalone) is index.docker.io
@@ -143,6 +145,7 @@ elliptics:
 dev: &dev
     <<: *local
     loglevel: _env:LOGLEVEL:debug
+    debug_versions: _env:DEBUG_VERSIONS:true
     search_backend: _env:SEARCH_BACKEND:sqlalchemy
 
 # This flavor is used by unit tests


### PR DESCRIPTION
For debugging it's good to know what package versions folks are
running.  This endpoint allows folks using floating dependencies (or
just different versions of docker-registry) to figure out the exact
version of all of their Python dependencies.

The only basic dependency that _doesn't_ define a **version** is
itsdangerous (as of v0.24), which doesn't provide a
programmatically-accessible version number.  I haven't checked all the
peripheral dependencies outside of what gets pulled in by a stock:

  $ pip install depends/docker-registry-core/
  $ pip install .

To avoid accidentally leaking implementation details, the /_versions
endpoint is disabled in the common config_sample.yml block, and only
enabled by default in the dev block.  In both cases, you can use the
VERSIONS environment variable to enable/disable the endpoint for your
particular instance.

This should make it easier for users to report which versions they're
using.  See [here](https://github.com/dotcloud/docker-registry/issues/466#issuecomment-49063166) and [here](https://github.com/dotcloud/docker-registry/issues/466#issuecomment-49165764).
