### PR TITLE
Remove unused or misnamed X-Docker-Payload-Checksum header.

### DIFF
--- a/docker_registry/images.py
+++ b/docker_registry/images.py
@@ -127,7 +127,7 @@ def _get_image_json(image_id, headers=None):
         pass
     try:
         csums = load_checksums(image_id)
-        headers['X-Docker-Payload-Checksum'] = csums
+        headers['X-Docker-Checksum-Payload'] = csums
     except exceptions.FileNotFoundError:
         pass
     return toolkit.response(data, headers=headers, raw=True)

--- a/tests/base.py
+++ b/tests/base.py
@@ -77,5 +77,5 @@ class TestCase(unittest.TestCase):
         resp = self.http_client.get('/v1/images/{0}/json'.format(image_id))
         self.assertEqual(resp.status_code, 200, resp.data)
         self.assertEqual(resp.headers.get('x-docker-size'), str(len(layer)))
-        self.assertEqual(resp.headers['x-docker-payload-checksum'],
+        self.assertEqual(resp.headers['x-docker-checksum-payload'],
                          layer_checksum)


### PR DESCRIPTION
Based on my understanding this header is ignored in the [GetRemoteImageJSON](https://github.com/dotcloud/docker/blob/master/registry/registry.go#L227) function. Otherwise IMHO the `X-Docker-Checksum-Payload` would be the proper name of the header.
