### PR TITLE
docker_registry.index: Remove local logger

### DIFF
--- a/docker_registry/index.py
+++ b/docker_registry/index.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging
-
 import flask
 import flask_cors
 
@@ -18,7 +16,6 @@ from .app import app
 
 
 store = storage.load()
-logger = logging.getLogger(__name__)
 
 """Those routes are loaded only when `standalone' is enabled in the config
    file. The goal is to make the Registry working without the central Index


### PR DESCRIPTION
This was added in d2ace65d (Naive mirroring implementation,
2014-02-06) in support of some
/v1/repositories/path:repository/images logging.  Those logs were
removed in bbb487a3 (Using mirroring decorator on index route,
2014-03-07), but this code was left behind.
