### PR TITLE
Configure logging before modules that require it

### DIFF
--- a/docker_registry/app.py
+++ b/docker_registry/app.py
@@ -14,13 +14,17 @@ import flask
 
 from . import toolkit
 from .lib import config
+
+# configure logging prior to subsequent imports which assume
+# logging has been configured
+cfg = config.load()
+logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
+                    level=getattr(logging, cfg.loglevel.upper()))
+
 from .lib import mirroring
 from .server import __version__
 
 app = flask.Flask('docker-registry')
-cfg = config.load()
-logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
-                    level=getattr(logging, cfg.loglevel.upper()))
 
 
 @app.route('/_ping')


### PR DESCRIPTION
In current master, starting up the registry with cache enabled results in a `No handlers could be found for logger "docker_registry.lib.cache"` error.

Here is a more complete error with a stack included for reference:

```
root@81a510819c96:/docker-registry# /app/bin/boot 
deis-registry running...
  File "/usr/local/bin/docker-registry", line 9, in <module>
    load_entry_point('docker-registry==0.8.0', 'console_scripts', 'docker-registry')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 2476, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 2190, in load
    ['__name__'])
  File "/usr/local/lib/python2.7/dist-packages/docker_registry-0.8.0-py2.7.egg/docker_registry/run.py", line 17, in <module>
    from .app import app  # noqa
  File "/usr/local/lib/python2.7/dist-packages/docker_registry-0.8.0-py2.7.egg/docker_registry/app.py", line 17, in <module>
    from .lib import mirroring
  File "/usr/local/lib/python2.7/dist-packages/docker_registry-0.8.0-py2.7.egg/docker_registry/lib/mirroring.py", line 10, in <module>
    from . import cache
  File "/usr/local/lib/python2.7/dist-packages/docker_registry-0.8.0-py2.7.egg/docker_registry/lib/cache.py", line 10, in <module>
    import traceback;traceback.print_stack()
No handlers could be found for logger "docker_registry.lib.cache"
2014-07-22 02:57:44,124 DEBUG: Will return docker-registry.drivers.file.Storage
```

This PR resolves the problem by moving `logging.basicConfig` prior to importing modules that assume logging is already setup.
