### PR TITLE
Update boto.py

### DIFF
--- a/depends/docker-registry-core/docker_registry/core/boto.py
+++ b/depends/docker-registry-core/docker_registry/core/boto.py
@@ -136,7 +136,7 @@ class Base(driver.Base):
         logger.info("Boto based storage initialized")
 
     def _build_connection_params(self):
-        kwargs = {'is_secure': (self._config.boto_secure is True)}
+        kwargs = {'is_secure': (self._config.s3_secure is True)}
         config_args = [
             'host', 'port', 'debug',
             'proxy', 'proxy_port',


### PR DESCRIPTION
There was an error where the wrong variable name was being used when loading the config variables. The storage object was trying to load the boto_secure file, which didn't exist since it was called s3_secure. Therefore the registry was never using HTTPS with s3.
