### PR TITLE
upgraded gunicorn, removed deprecated flag, and added timezone to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ sudo python-pip install docker-registry[bugsnag]
 #### Run it
 
 ```
-gunicorn --access-logfile - --debug -k gevent -b 0.0.0.0:5000 -w 1 docker_registry.wsgi:application
+gunicorn --access-logfile - -k gevent -b 0.0.0.0:5000 -w 4 --max-requests 100 docker_registry.wsgi:application
 ```
 
 ### How do I setup user accounts?

--- a/docker_registry/app.py
+++ b/docker_registry/app.py
@@ -19,7 +19,8 @@ from .lib import config
 # logging has been configured
 cfg = config.load()
 logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
-                    level=getattr(logging, cfg.loglevel.upper()))
+                    level=getattr(logging, cfg.loglevel.upper()),
+                    datefmt="%d/%b/%Y:%H:%M:%S %z")
 
 from .lib import mirroring
 from .server import __version__

--- a/docker_registry/run.py
+++ b/docker_registry/run.py
@@ -41,6 +41,7 @@ GUNICORN_USER: unix user to downgrade priviledges to
 GUNICORN_GROUP: unix group to downgrade priviledges to
 GUNICORN_ACCESS_LOG_FILE: File to log access to
 GUNICORN_ERROR_LOG_FILE: File to log errors to
+GUNICORN_OPTS: extra options to pass to gunicorn
 """
 
 
@@ -70,7 +71,6 @@ def run_gunicorn():
         gunicorn_path, 'gunicorn',
         '--access-logfile', env.source('GUNICORN_ACCESS_LOG_FILE'),
         '--error-logfile', env.source('GUNICORN_ERROR_LOG_FILE'),
-        '--debug',
         '--max-requests', '100',
         '-k', 'gevent',
         '--graceful-timeout', env.source('GUNICORN_GRACEFUL_TIMEOUT'),

--- a/docker_registry/wsgi.py
+++ b/docker_registry/wsgi.py
@@ -22,9 +22,6 @@ if __name__ == '__main__':
     port = env.source('REGISTRY_PORT')
     app.debug = True
     app.run(host=host, port=port)
-    # Or you can run:
-    # gunicorn --access-logfile - --log-level debug --debug -b 0.0.0.0:5000 \
-    #  -w 1 wsgi:application
 else:
     # For uwsgi
     app.logger.setLevel(logging.INFO)

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -2,7 +2,7 @@ blinker==1.3
 Flask==0.10.1
 Flask-cors==1.3.0
 gevent==1.0.1
-gunicorn==18.0
+gunicorn==19.1
 PyYAML==3.11
 requests==2.3.0
 rsa==3.1.4


### PR DESCRIPTION
Upgrade of gunicorn brings it to a version that includes timezone in access log. As far as I can tell it's working - there appear to be two bugs in running the nose tests that also exist in 0.7.3, unless I'm running it wrong.
