### PR TITLE
Added CORS support to 'ping', 'get images' and 'get tags' methods in registry REST api

### DIFF
--- a/docker_registry/app.py
+++ b/docker_registry/app.py
@@ -16,6 +16,7 @@ from . import toolkit
 from .lib import config
 from .server import __version__
 import flask
+import flask_cors
 
 # configure logging prior to subsequent imports which assume
 # logging has been configured
@@ -31,6 +32,7 @@ app = flask.Flask('docker-registry')
 
 @app.route('/_ping')
 @app.route('/v1/_ping')
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 def ping():
     headers = {'X-Docker-Registry-Standalone': cfg.standalone is True}
     if mirroring.is_mirror():

--- a/docker_registry/images.py
+++ b/docker_registry/images.py
@@ -6,6 +6,7 @@ import logging
 import time
 
 import flask
+import flask_cors
 
 from docker_registry.core import compat
 from docker_registry.core import exceptions
@@ -313,6 +314,7 @@ def get_private_image_json(image_id):
 
 
 @app.route('/v1/images/<image_id>/json', methods=['GET'])
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 @toolkit.requires_auth
 @require_completion
 @set_cache_headers

--- a/docker_registry/tags.py
+++ b/docker_registry/tags.py
@@ -6,6 +6,7 @@ import re
 import time
 
 import flask
+import flask_cors
 
 from docker_registry.core import compat
 from docker_registry.core import exceptions
@@ -73,6 +74,7 @@ def get_tags(namespace, repository):
 
 
 @app.route('/v1/repositories/<path:repository>/tags', methods=['GET'])
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 @mirroring.source_lookup_tag
@@ -89,6 +91,7 @@ def _get_tags(namespace, repository):
 
 
 @app.route('/v1/repositories/<path:repository>/tags/<tag>', methods=['GET'])
+@flask_cors.cross_origin(methods=['GET'])  # allow all origins (*)
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 @mirroring.source_lookup_tag


### PR DESCRIPTION
I’m trying to build a [web interface](http://l3n41c.github.io/private_docker_registry_browser) on top of docker registries in order to provide a convenient way to browse the content of private registries.

In order for the browser to be able to use the REST API, it needs to implement [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing).

This problematic has already been described in #333.
The CORS support has already been implemented for the “search” API in #338.

This pull request adds CORS support for the “ping”, “list tags” and “image info” APIs.
