### PR TITLE
Fix bugs when using MySQL as index database

### DIFF
--- a/docker_registry/lib/index/db.py
+++ b/docker_registry/lib/index/db.py
@@ -32,8 +32,10 @@ class Repository (Base):
 
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
     name = sqlalchemy.Column(
-        sqlalchemy.String, nullable=False, unique=True)
-    description = sqlalchemy.Column(sqlalchemy.String)
+        sqlalchemy.String(length=30 + 1 + 64),  # namespace / respository
+        nullable=False, unique=True)
+    description = sqlalchemy.Column(
+        sqlalchemy.String(length=100))
 
     def __repr__(self):
         return "<{0}(name='{1}', description='{2}')>".format(
@@ -61,10 +63,10 @@ class SQLAlchemyIndex (Index):
 
     def _setup_database(self):
         session = self._session()
-        try:
+        if self._engine.has_table(table_name=Version.__tablename__):
             version = session.query(
                 sqlalchemy.sql.functions.max(Version.id)).first()[0]
-        except sqlalchemy.exc.OperationalError:
+        else:
             version = None
         if version:
             if version != self.version:

--- a/tests/lib/index/test_db.py
+++ b/tests/lib/index/test_db.py
@@ -28,8 +28,9 @@ class TestSQLAlchemyIndex(unittest.TestCase):
     def setUp(self):
         self.index = db.SQLAlchemyIndex(database="sqlite://")
 
+    @mock.patch('sqlalchemy.engine.Engine.has_table', return_value=True)
     @mock.patch('sqlalchemy.orm.query.Query.first')
-    def test_setup_database(self, first):
+    def test_setup_database(self, first, has_table):
         first = mock.Mock(  # noqa
             side_effect=db.sqlalchemy.exc.OperationalError)
         self.assertRaises(


### PR DESCRIPTION
1. MySQLdb will raise `ProgrammingError` if table doesn't exists. Use `engine.has_table` to check whether table exists for compatible
2. VARCHAR requires a length on dialect mysql. String length limit is according to [Docker Hub's limit](https://registry.hub.docker.com/account/repositories/add/)
