### PR TITLE
Fix up flake8 H302

### DIFF
--- a/docker_registry/app.py
+++ b/docker_registry/app.py
@@ -16,7 +16,7 @@ from . import toolkit
 from .lib import config
 from .server import __version__
 import flask
-from flask.ext.cors import CORS
+import flask.ext.cors
 
 # configure logging prior to subsequent imports which assume
 # logging has been configured
@@ -113,7 +113,7 @@ def init():
     # Configure flask_cors
     for i in cfg.cors.keys():
         app.config['CORS_%s' % i.upper()] = cfg.cors[i]
-    CORS(app)
+    flask.ext.cors.CORS(app)
 
 
 def _adapt_smtp_secure(value):


### PR DESCRIPTION
CI fails in PR #555 which is irrelevant to it. So I send another PR to fix.
It's strange that it didn't fail in master's CI.

https://travis-ci.org/docker/docker-registry/jobs/34466985#L785

```
./docker_registry/app.py:19:1: H302  import only modules.'from flask.ext.cors import CORS' does not import a module
```
