### PR TITLE
Fix cache disabled warn levels

### DIFF
--- a/docker_registry/lib/cache.py
+++ b/docker_registry/lib/cache.py
@@ -24,7 +24,7 @@ def init():
 def enable_redis_cache(cache, path):
     global redis_conn, cache_prefix
     if not cache or not cache.host:
-        logger.warn('Cache storage disabled!')
+        logger.info('Cache not enabled.')
         return
 
     logger.info('Enabling storage cache on Redis')
@@ -42,7 +42,7 @@ def enable_redis_cache(cache, path):
 
 def enable_redis_lru(cache, path):
     if not cache or not cache.host:
-        logger.warn('LRU cache disabled!')
+        logger.info('LRU cache not enabled.')
         return
     logger.info('Enabling lru cache on Redis')
     logger.info(

--- a/tests/lib/test_cache.py
+++ b/tests/lib/test_cache.py
@@ -19,7 +19,7 @@ class TestCache(TestCase):
         self.assertEqual(cache.redis_conn, None)
         self.assertEqual(cache.cache_prefix, None)
         cache.enable_redis_cache(None, None)
-        self.assertEqual(logger.warn.call_count, 1)
+        self.assertEqual(logger.info.call_count, 1)
 
         cache.enable_redis_cache(self.cache, None)
         self.assertTrue(cache.redis_conn is not None)
@@ -34,10 +34,10 @@ class TestCache(TestCase):
     @mock.patch.object(cache.lru, 'init')
     def test_enable_redis_lru(self, lru_init, logger):
         cache.enable_redis_lru(None, None)
-        self.assertEqual(logger.warn.call_count, 1)
+        self.assertEqual(logger.info.call_count, 1)
 
         cache.enable_redis_lru(self.cache, None)
-        self.assertEqual(logger.info.call_count, 2)
+        self.assertEqual(logger.info.call_count, 3)
         lru_init.assert_called_once_with(
             host=self.cache.host, port=self.cache.port, db=self.cache.db,
             password=self.cache.password, path='/')


### PR DESCRIPTION
From reading the [README](https://github.com/docker/docker-registry#cache-options) configuring a cache / LRU cache is nice-to-have, but not required. A 'WARNING' feels more like something, which should be fixed asap.

Ref: https://github.com/deis/deis/issues/1780
