### PR TITLE
Add import_modules to config

### DIFF
--- a/docker_registry/lib/config.py
+++ b/docker_registry/lib/config.py
@@ -2,6 +2,8 @@
 
 import os
 
+import importlib  # noqa
+
 import rsa
 import yaml
 
@@ -117,5 +119,12 @@ def load():
 
     if _config.index_endpoint:
         _config.index_endpoint = _config.index_endpoint.strip('/')
+
+    if _config.import_modules:
+        for module in _config.import_modules:
+            try:
+                importlib.import_module(module)
+            except ImportError:
+                raise exceptions.ConfigError("Failed to import '%s'" % module)
 
     return _config

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -31,3 +31,7 @@ ENV:
     bugger: _env:BUGGER:bug:me:endlessly
     array: _env:ARRAY:[one, two, three]
     dict: _env:DICT
+
+IMPORT:
+    import_modules:
+        - some.module

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,3 +165,23 @@ class TestLoad(unittest.TestCase):
     def test_config_path_exception(self, get):
         config._config = None
         self.assertRaises(config.exceptions.FileNotFoundError, config.load)
+
+    @mock.patch('importlib.import_module')
+    def test_import_modules(self, mockImport):
+        config._config = None
+        p = os.path.join(
+            os.path.dirname(__file__), 'fixtures', 'test_config.yaml')
+        env = {'SETTINGS_FLAVOR': 'IMPORT', 'DOCKER_REGISTRY_CONFIG': p}
+        with mock.patch.dict(config.os.environ, env):
+            config.load()
+            mockImport.assert_called_with('some.module')
+
+    @mock.patch('importlib.import_module')
+    def test_import_modules_import_error(self, mockImport):
+        config._config = None
+        p = os.path.join(
+            os.path.dirname(__file__), 'fixtures', 'test_config.yaml')
+        env = {'SETTINGS_FLAVOR': 'IMPORT', 'DOCKER_REGISTRY_CONFIG': p}
+        with mock.patch.dict(config.os.environ, env):
+            mockImport.side_effect = ImportError()
+            self.assertRaises(config.exceptions.ConfigError, config.load)


### PR DESCRIPTION
Add optional import_modules to config - if specified, each module will
be imported. This allows external code to be loaded at runtime - for
example, to connect an additional method to a signal for custom
processing when a tag is created, etc.

Related to #493
