### PR TITLE
Add image to tag_deleted signal payload

### DIFF
--- a/docker_registry/tags.py
+++ b/docker_registry/tags.py
@@ -208,14 +208,17 @@ def put_tag(namespace, repository, tag):
 def delete_tag(namespace, repository, tag):
     logger.debug("[delete_tag] namespace={0}; repository={1}; tag={2}".format(
                  namespace, repository, tag))
-    store.remove(store.tag_path(namespace, repository, tag))
+    tag_path = store.tag_path(namespace, repository, tag)
+    image = store.get_content(path=tag_path)
+    store.remove(tag_path)
     store.remove(store.repository_tag_json_path(namespace, repository,
                                                 tag))
     sender = flask.current_app._get_current_object()
     if tag == "latest":  # TODO(wking) : deprecate this for v2
         store.remove(store.repository_json_path(namespace, repository))
     signals.tag_deleted.send(
-        sender, namespace=namespace, repository=repository, tag=tag)
+        sender, namespace=namespace, repository=repository, tag=tag,
+        image=image)
 
 
 @app.route('/v1/repositories/<path:repository>/tags/<tag>',


### PR DESCRIPTION
Add image to tag_deleted signal payload. This is useful for things
such as a refcount extension, which needs to know the image id that was
associated with the deleted tag so refcounts can be updated accordingly.

Extracted from the refcount PR #409 in preparation for making it a standalone extension via #566 

@wking @dmp42 please review when you get a chance
