### PR TITLE
Explicitly require setuptools

### DIFF
--- a/depends/docker-registry-core/requirements/main.txt
+++ b/depends/docker-registry-core/requirements/main.txt
@@ -1,2 +1,3 @@
 boto==2.32.1
 redis==2.10.3
+setuptools==5.8

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -7,3 +7,4 @@ PyYAML==3.11
 requests==2.3.0
 rsa==3.1.4
 sqlalchemy==0.9.4
+setuptools==5.8


### PR DESCRIPTION
Add explicit dependency on setuptools, since we use pkg_resources from
it.
