### PR TITLE
Add before_put_image_json signal

### DIFF
--- a/docker_registry/lib/signals.py
+++ b/docker_registry/lib/signals.py
@@ -13,3 +13,8 @@ repository_deleted = _signals.signal('repository-deleted')
 # Triggered when a tag is modified (registry/tags.py)
 tag_created = _signals.signal('tag-created')
 tag_deleted = _signals.signal('tag-deleted')
+
+# Triggered after all put_image_json validations have passed but before
+# actually storing anything. Any non-None return value from the signalled
+# subscribers will result in the put_image_json operation being cancelled.
+before_put_image_json = _signals.signal('before-put-image-json')


### PR DESCRIPTION
Add before_put_image_json signal that allows receivers to short-circuit
the put if they return any non-None value. This can be useful for things
such as enforcing quotas, e.g. by having a custom extension connect to
this signal, check the layer's Size, and returning something to the
effect that the put was denied due to quota.

Signed-off-by: Andy Goldstein agoldste@redhat.com
