### PR TITLE
Add logger name to log format

### DIFF
--- a/docker_registry/app.py
+++ b/docker_registry/app.py
@@ -15,7 +15,7 @@ import flask
 # configure logging prior to subsequent imports which assume
 # logging has been configured
 cfg = config.load()
-logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
+logging.basicConfig(format='%(asctime)s %(levelname)s: [%(name)s] %(message)s',
                     level=getattr(logging, cfg.loglevel.upper()),
                     datefmt="%d/%b/%Y:%H:%M:%S %z")
 

--- a/docker_registry/wsgi.py
+++ b/docker_registry/wsgi.py
@@ -44,6 +44,6 @@ else:
     stderr_logger = logging.StreamHandler()
     stderr_logger.setLevel(level)
     stderr_logger.setFormatter(
-        logging.Formatter('%(asctime)s %(levelname)s: %(message)s'))
+        logging.Formatter('%(asctime)s %(levelname)s: [%(name)s] %(message)s'))
     app.logger.addHandler(stderr_logger)
     application = app


### PR DESCRIPTION
Add %(name)s to log format so log messages are prefixed with the
logger's name.

Signed-off-by: Andy Goldstein agoldste@redhat.com
