### PR TITLE
Allow pluggable index delegate

### DIFF
--- a/docker_registry/fakeindex.py
+++ b/docker_registry/fakeindex.py
@@ -1,0 +1,104 @@
+import flask
+
+from docker_registry.core import compat
+from docker_registry.core import exceptions
+json = compat.json
+
+from . import storage
+from . import toolkit
+from .lib import signals
+
+
+store = storage.load()
+
+
+def generate_headers(namespace, repository, access):
+    registry_endpoints = toolkit.get_endpoints()
+    # The token generated will be invalid against a real Index behind.
+    token = 'Token signature={0},repository="{1}/{2}",access={3}'.format(
+            toolkit.gen_random_string(), namespace, repository, access)
+    return {'X-Docker-Endpoints': registry_endpoints,
+            'WWW-Authenticate': token,
+            'X-Docker-Token': token}
+
+
+def get_users():
+    return toolkit.response('OK', 200)
+
+
+def post_users():
+    try:
+        # Note(dmp): unicode patch
+        json.loads(flask.request.data.decode('utf8'))
+    except ValueError:
+        return toolkit.api_error('Error Decoding JSON', 400)
+    return toolkit.response('User Created', 201)
+
+
+def put_username(username):
+    return toolkit.response('', 204)
+
+
+def put_repository(namespace, repository, images=False):
+    data = None
+    try:
+        # Note(dmp): unicode patch
+        data = json.loads(flask.request.data.decode('utf8'))
+    except ValueError:
+        return toolkit.api_error('Error Decoding JSON', 400)
+    if not isinstance(data, list):
+        return toolkit.api_error('Invalid data')
+    update_index_images(namespace, repository, flask.request.data)
+    headers = generate_headers(namespace, repository, 'write')
+    code = 204 if images is True else 200
+    return toolkit.response('', code, headers)
+
+
+def get_repository_images(namespace, repository):
+    data = None
+    try:
+        path = store.index_images_path(namespace, repository)
+        data = store.get_content(path)
+    except exceptions.FileNotFoundError:
+        return toolkit.api_error('images not found', 404)
+    headers = generate_headers(namespace, repository, 'read')
+    return toolkit.response(data, 200, headers, True)
+
+
+def delete_repository_images(namespace, repository):
+    # Does nothing, this file will be removed when DELETE on repos
+    headers = generate_headers(namespace, repository, 'delete')
+    return toolkit.response('', 204, headers)
+
+
+def put_repository_auth(namespace, repository):
+    return toolkit.response('OK')
+
+
+def update_index_images(namespace, repository, data):
+    path = store.index_images_path(namespace, repository)
+    sender = flask.current_app._get_current_object()
+    try:
+        images = {}
+        # Note(dmp): unicode patch
+        data = json.loads(data.decode('utf8')) + store.get_json(path)
+        for i in data:
+            iid = i['id']
+            if iid in images and 'checksum' in images[iid]:
+                continue
+            i_data = {'id': iid}
+            for key in ['checksum']:
+                if key in i:
+                    i_data[key] = i[key]
+            images[iid] = i_data
+        data = images.values()
+        # Note(dmp): unicode patch
+        store.put_json(path, data)
+        signals.repository_updated.send(
+            sender, namespace=namespace, repository=repository, value=data)
+    except exceptions.FileNotFoundError:
+        signals.repository_created.send(
+            sender, namespace=namespace, repository=repository,
+            # Note(dmp): unicode patch
+            value=json.loads(data.decode('utf8')))
+        store.put_content(path, data)

--- a/docker_registry/index.py
+++ b/docker_registry/index.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 
-import flask
-
 from docker_registry.core import compat
-from docker_registry.core import exceptions
 json = compat.json
 
-from . import storage
 from . import toolkit
+from .lib import config
 from .lib import mirroring
-from .lib import signals
 
 from .app import app  # noqa
 
 
-store = storage.load()
+cfg = config.load()
+if cfg.index_delegate is None:
+    import docker_registry.fakeindex
+    cfg.index_delegate = docker_registry.fakeindex
+
 
 """Those routes are loaded only when `standalone' is enabled in the config
    file. The goal is to make the Registry working without the central Index
@@ -23,61 +23,21 @@ store = storage.load()
 """
 
 
-def generate_headers(namespace, repository, access):
-    registry_endpoints = toolkit.get_endpoints()
-    # The token generated will be invalid against a real Index behind.
-    token = 'Token signature={0},repository="{1}/{2}",access={3}'.format(
-            toolkit.gen_random_string(), namespace, repository, access)
-    return {'X-Docker-Endpoints': registry_endpoints,
-            'WWW-Authenticate': token,
-            'X-Docker-Token': token}
+@app.route('/v1/users', methods=['GET'])
+@app.route('/v1/users/', methods=['GET'])
+def get_users():
+    return cfg.index_delegate.get_users()
 
 
-@app.route('/v1/users', methods=['GET', 'POST'])
-@app.route('/v1/users/', methods=['GET', 'POST'])
-def get_post_users():
-    if flask.request.method == 'GET':
-        return toolkit.response('OK', 200)
-    try:
-        # Note(dmp): unicode patch
-        json.loads(flask.request.data.decode('utf8'))
-    except ValueError:
-        return toolkit.api_error('Error Decoding JSON', 400)
-    return toolkit.response('User Created', 201)
+@app.route('/v1/users', methods=['POST'])
+@app.route('/v1/users/', methods=['POST'])
+def post_users():
+    return cfg.index_delegate.post_users()
 
 
 @app.route('/v1/users/<username>/', methods=['PUT'])
 def put_username(username):
-    return toolkit.response('', 204)
-
-
-def update_index_images(namespace, repository, data):
-    path = store.index_images_path(namespace, repository)
-    sender = flask.current_app._get_current_object()
-    try:
-        images = {}
-        # Note(dmp): unicode patch
-        data = json.loads(data.decode('utf8')) + store.get_json(path)
-        for i in data:
-            iid = i['id']
-            if iid in images and 'checksum' in images[iid]:
-                continue
-            i_data = {'id': iid}
-            for key in ['checksum']:
-                if key in i:
-                    i_data[key] = i[key]
-            images[iid] = i_data
-        data = images.values()
-        # Note(dmp): unicode patch
-        store.put_json(path, data)
-        signals.repository_updated.send(
-            sender, namespace=namespace, repository=repository, value=data)
-    except exceptions.FileNotFoundError:
-        signals.repository_created.send(
-            sender, namespace=namespace, repository=repository,
-            # Note(dmp): unicode patch
-            value=json.loads(data.decode('utf8')))
-        store.put_content(path, data)
+    return cfg.index_delegate.put_username(username)
 
 
 @app.route('/v1/repositories/<path:repository>', methods=['PUT'])
@@ -87,18 +47,7 @@ def update_index_images(namespace, repository, data):
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 def put_repository(namespace, repository, images=False):
-    data = None
-    try:
-        # Note(dmp): unicode patch
-        data = json.loads(flask.request.data.decode('utf8'))
-    except ValueError:
-        return toolkit.api_error('Error Decoding JSON', 400)
-    if not isinstance(data, list):
-        return toolkit.api_error('Invalid data')
-    update_index_images(namespace, repository, flask.request.data)
-    headers = generate_headers(namespace, repository, 'write')
-    code = 204 if images is True else 200
-    return toolkit.response('', code, headers)
+    return cfg.index_delegate.put_repository(namespace, repository, images)
 
 
 @app.route('/v1/repositories/<path:repository>/images', methods=['GET'])
@@ -106,26 +55,17 @@ def put_repository(namespace, repository, images=False):
 @toolkit.requires_auth
 @mirroring.source_lookup(index_route=True)
 def get_repository_images(namespace, repository):
-    data = None
-    try:
-        path = store.index_images_path(namespace, repository)
-        data = store.get_content(path)
-    except exceptions.FileNotFoundError:
-        return toolkit.api_error('images not found', 404)
-    headers = generate_headers(namespace, repository, 'read')
-    return toolkit.response(data, 200, headers, True)
+    return cfg.index_delegate.get_repository_images(namespace, repository)
 
 
 @app.route('/v1/repositories/<path:repository>/images', methods=['DELETE'])
 @toolkit.parse_repository_name
 @toolkit.requires_auth
 def delete_repository_images(namespace, repository):
-    # Does nothing, this file will be removed when DELETE on repos
-    headers = generate_headers(namespace, repository, 'delete')
-    return toolkit.response('', 204, headers)
+    return cfg.index_delegate.delete_repository_images(namespace, repository)
 
 
 @app.route('/v1/repositories/<path:repository>/auth', methods=['PUT'])
 @toolkit.parse_repository_name
 def put_repository_auth(namespace, repository):
-    return toolkit.response('OK')
+    return cfg.index_delegate.put_repository_auth(namespace, repository)

--- a/docker_registry/wsgi.py
+++ b/docker_registry/wsgi.py
@@ -27,7 +27,7 @@ if cfg.search_backend:
     from .search import *  # noqa
 
 if cfg.standalone:
-    # If standalone mode is enabled, load the fake Index routes
+    # If standalone mode is enabled, load the Index routes
     from .index import *  # noqa
 
 if __name__ == '__main__':


### PR DESCRIPTION
Move index logic into fakeindex and allow user to specify a different
module to use to handle the index routes.

Signed-off-by: Andy Goldstein agoldste@redhat.com
