### PR TITLE
fix forgotten lowercase cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ ENV SETTINGS_FLAVOR dev
 
 EXPOSE 5000
 
-cmd ["docker-registry"]
+CMD ["docker-registry"]


### PR DESCRIPTION
I'm sorry, I missed one important instruction when converting all instructions to uppercase in #620.
