### PR TITLE
Config template: add boto_calling_format S3 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ AWS Simple Storage Service options
 1. `boto_host`: string, host for *non*-Amazon S3-compliant object store
 1. `boto_port`: for *non*-Amazon S3-compliant object store
 1. `boto_debug`: for *non*-Amazon S3-compliant object store
-1. `boto_calling_format`: for *non*-Amazon S3-compliant object store
+1. `boto_calling_format`: string, the fully qualified class name of the boto calling format to use when accessing S3 or a *non*-Amazon S3-compliant object store
 1. `storage_path`: string, the sub "folder" where image data will be stored.
 
 Example:

--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -86,6 +86,7 @@ s3: &s3
     s3_secret_key: _env:AWS_SECRET
     boto_host: _env:AWS_HOST
     boto_port: _env:AWS_PORT
+    boto_calling_format: _env:AWS_CALLING_FORMAT
 
 # Ceph Object Gateway Configuration
 # See http://ceph.com/docs/master/radosgw/ for details on installing this service.


### PR DESCRIPTION
Using the "ordinary" calling format can be useful when using
a bucket whose name contains periods (otherwise the AWS SSL
certificate may be refused because it is several subdomains
deep).
