### PR TITLE
README.md: Document --preload for the SQLAlchemy search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ common:
   sqlalchemy_index_database: sqlite:////tmp/docker-registry.db
 ```
 
+On initialization, the `SQLAlchemyIndex` class checks the database
+version.  If the database doesn't exist yet (or does exist, but lacks
+a `version` table), the `SQLAlchemyIndex` creates the database and
+required tables.  To avoid several Gunicorn workers racing to create
+the database, you should launch your registry with
+[--preload][gunicorn-preload].  For example:
+
+    $ docker run -e GUNICORN_OPTS='[--preload]' -p 5000:5000 registry
+
 ### Mirroring Options
 
 All mirror options are placed in a `mirroring` section.
@@ -338,3 +347,4 @@ Read [contributing](CONTRIBUTING.md)
 [search-endpoint]: http://docs.docker.com/reference/api/docker-io_api/#search
 [SQLAlchemy]: http://docs.sqlalchemy.org/
 [create_engine]: http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
+[gunicorn-preload]: http://gunicorn-docs.readthedocs.org/en/latest/settings.html#preload-app


### PR DESCRIPTION
And move the `Index` discussion to the right place.  See [here](https://github.com/docker/docker-registry/issues/518#issuecomment-60701851).
