### PR TITLE
avoid using a variable twice in the same function

### DIFF
--- a/docker_registry/index.py
+++ b/docker_registry/index.py
@@ -51,13 +51,13 @@ def put_username(username):
     return toolkit.response('', 204)
 
 
-def update_index_images(namespace, repository, data):
+def update_index_images(namespace, repository, data_arg):
     path = store.index_images_path(namespace, repository)
     sender = flask.current_app._get_current_object()
     try:
         images = {}
         # Note(dmp): unicode patch
-        data = json.loads(data.decode('utf8')) + store.get_json(path)
+        data = json.loads(data_arg.decode('utf8')) + store.get_json(path)
         for i in data:
             iid = i['id']
             if iid in images and 'checksum' in images[iid]:
@@ -76,8 +76,8 @@ def update_index_images(namespace, repository, data):
         signals.repository_created.send(
             sender, namespace=namespace, repository=repository,
             # Note(dmp): unicode patch
-            value=json.loads(data.decode('utf8')))
-        store.put_content(path, data)
+            value=json.loads(data_arg.decode('utf8')))
+        store.put_content(path, data_arg)
 
 
 @app.route('/v1/repositories/<path:repository>', methods=['PUT'])


### PR DESCRIPTION
This code issue was discovered during code review while investigating docker-push failures by our private docker registry. The docker client didn't provide details about the failure, but the registry logfile pointed to exception that was raised inside **update_index_images()**.

The problem is the **data** variable that is passed as _string_ to **update_index_images()** but later on a _list_ is assigned to it. However the exception handler assumes the variable is still a _string_, and when that happens another exception is raised which is not handled properly by the code (and should not occur in the first place).
