### PR TITLE
Azure Storage Driver config and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ In the `config_sample.yml` file, you'll see several sample flavors:
 1. `local`: stores data on the local filesystem
 1. `s3`: stores data in an AWS S3 bucket
 1. `ceph-s3`: stores data in a Ceph cluster via a Ceph Object Gateway, using the S3 API
+1. `azure`: stores data in an Microsoft Azure Blob Storage
 1. `dev`: basic configuration using the `local` flavor
 1. `test`: used by unit tests
 1. `prod`: production configuration (basically a synonym for the `s3` flavor)
@@ -264,6 +265,7 @@ To use and install one of these alternate storages:
 
  Currently, we are aware of the following storage drivers:
 
+  * [azure](https://github.com/ahmetalpbalkan/docker-registry-driver-azure)
   * [elliptics](https://github.com/noxiouz/docker-registry-driver-elliptics)
   * [swift](https://github.com/bacongobbler/docker-registry-driver-swift)
   * [gcs](https://github.com/dmp42/docker-registry-driver-gcs)

--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -89,6 +89,15 @@ s3: &s3
     boto_port: _env:AWS_PORT
     boto_calling_format: _env:AWS_CALLING_FORMAT
 
+
+azureblob: &azureblob
+    <<: *common
+    storage: azureblob
+    azure_storage_account_name: _env:AZURE_STORAGE_ACCOUNT_NAME
+    azure_storage_account_key: _env:AZURE_STORAGE_ACCOUNT_KEY
+    azure_storage_container: _env:AZURE_STORAGE_CONTAINER:registry
+    azure_use_https: _env:AZURE_USE_HTTPS:true
+
 # Ceph Object Gateway Configuration
 # See http://ceph.com/docs/master/radosgw/ for details on installing this service.
 ceph-s3: &ceph-s3


### PR DESCRIPTION
This is our [Docker Global Hack Day #2](https://blog.docker.com/2014/10/announcing-docker-global-hack-day-2/) project!

We were able to run the docker registry on [Azure Blob Storage](http://azure.microsoft.com/en-us/documentation/services/storage/) using our [**`docker-registry-driver-azure`**](https://github.com/ahmetalpbalkan/docker-registry-driver-azure).

`docker-registry-driver-azure` is not yet ready via `pip install` but we provide a docker image called [ahmetalpbalkan/registry-azure](https://hub.docker.com/u/ahmetalpbalkan/registry-azure/) on Docker Hub. But we're planning to make it available via pip as well, soon.

We called this new flavor name "**azureblob**" instead of "azure" because then inside azure.py, we cannot import [Azure Python SDK](https://github.com/Azure/azure-sdk-for-python) using _"import azure"_ or _"from azure import storage"_
