### PR TITLE
Add DRIVERS.md for implemented docker-registry drivers

### DIFF
--- a/DRIVERS.md
+++ b/DRIVERS.md
@@ -1,0 +1,9 @@
+
+# Drivers
+
+* [docker-registry-driver-gcs](https://github.com/dmp42/docker-registry-driver-gcs)
+* [docker-registry-driver-swift](https://github.com/bacongobbler/docker-registry-driver-swift)
+* [docker-registry-driver-qiniu](https://github.com/zhangpeihao/docker-registry-driver-qiniu)
+* [docker-registry-driver-hdfs](https://github.com/lyda/docker-registry-driver-hdfs)
+* [docker-registry-driver-sinastorage](https://github.com/kerwin/docker-registry-driver-sinastorage)
+

--- a/README.md
+++ b/README.md
@@ -334,12 +334,15 @@ Then, start your registry with a mount point to expose your new configuration in
 sudo docker run -p 5000:5000 -v /home/me/myfolder:/registry-conf -e DOCKER_REGISTRY_CONFIG=/registry-conf/mysuperconfig.yml registry
 ```
 
-
 Advanced use
 ============
 
 For more features and advanced options, have a look at the [advanced features documentation](ADVANCED.md) 
 
+Drivers
+=======
+
+For more backend drivers, please read [drivers.md](DRIVERS.md)
 
 For developers
 ==============
@@ -350,3 +353,4 @@ Read [contributing](CONTRIBUTING.md)
 [SQLAlchemy]: http://docs.sqlalchemy.org/
 [create_engine]: http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
 [gunicorn-preload]: http://gunicorn-docs.readthedocs.org/en/latest/settings.html#preload-app
+


### PR DESCRIPTION
Now some developers have implemented the excellent drivers for docker-registry. I think the official repository should display all the verified drivers so that everyone can choose what drivers they want.

For simplicity, I just add DRIVERS.md and the anchor in README.md :smile_cat: 
