### PR TITLE
Add docker-registry-driver-elliptics in DRIVERS.md

### DIFF
--- a/DRIVERS.md
+++ b/DRIVERS.md
@@ -1,7 +1,7 @@
 
 # Drivers
 
-* [docker-registry-driver-gcs](https://github.com/dmp42/docker-registry-driver-gcs)
+* [docker-registry-driver-elliptics](https://github.com/noxiouz/docker-registry-driver-elliptics)
 * [docker-registry-driver-swift](https://github.com/bacongobbler/docker-registry-driver-swift)
 * [docker-registry-driver-qiniu](https://github.com/zhangpeihao/docker-registry-driver-qiniu)
 * [docker-registry-driver-hdfs](https://github.com/lyda/docker-registry-driver-hdfs)


### PR DESCRIPTION
@dmp42 Please have a look :-)

If the docker-registry-driver-gcs works, I think we should not remove it :smiley: 
