### PR TITLE
Adds versioning for out-of-process storage driver

### DIFF
--- a/storagedriver/README.md
+++ b/storagedriver/README.md
@@ -40,6 +40,8 @@ Storage drivers should call `factory.Register` with their driver name in an `ini
 ### Out-of-process drivers
 As many users will run the registry as a pre-constructed docker container, storage drivers should also be distributable as IPC server executables. Drivers written in go should model the main method provided in `main/storagedriver/filesystem/filesystem.go`. Parameters to IPC drivers will be provided as a JSON-serialized map in the first argument to the process. These parameters should be validated and then a blocking call to `ipc.StorageDriverServer` should be made with a new storage driver.
 
+Out-of-process drivers must also implement the `ipc.IPCStorageDriver` interface, which exposes a `Version` check for the storage driver. This is used to validate storage driver api compatibility at driver load-time.
+
 ## Testing
 Storage driver test suites are provided in `storagedriver/testsuites/testsuites.go` and may be used for any storage driver written in go. Two methods are provided for registering test suites, `RegisterInProcessSuite` and `RegisterIPCSuite`, which run the same set of tests for the driver imported or managed over IPC respectively.
 

--- a/storagedriver/ipc/ipc.go
+++ b/storagedriver/ipc/ipc.go
@@ -5,8 +5,28 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/docker/docker-registry/storagedriver"
 	"github.com/docker/libchan"
 )
+
+// IPCStorageDriver is the interface which IPC storage drivers must implement. As external storage
+// drivers may be defined to use a different version of the storagedriver.StorageDriver interface,
+// we use an additional version check to determine compatiblity.
+type IPCStorageDriver interface {
+	// Version returns the storagedriver.StorageDriver interface version which this storage driver
+	// implements, which is used to determine driver compatibility
+	Version() (storagedriver.Version, error)
+}
+
+// IncompatibleVersionError is returned when a storage driver is using an incompatible version of
+// the storagedriver.StorageDriver api
+type IncompatibleVersionError struct {
+	version storagedriver.Version
+}
+
+func (e IncompatibleVersionError) Error() string {
+	return fmt.Sprintf("Incompatible storage driver version: %s", e.version)
+}
 
 // Request defines a remote method call request
 // A return value struct is to be sent over the ResponseChannel
@@ -37,6 +57,12 @@ func (err *responseError) Error() string {
 }
 
 // IPC method call response object definitions
+
+// VersionResponse is a response for a Version request
+type VersionResponse struct {
+	Version storagedriver.Version
+	Error   *responseError
+}
 
 // ReadStreamResponse is a response for a ReadStream request
 type ReadStreamResponse struct {

--- a/storagedriver/ipc/server.go
+++ b/storagedriver/ipc/server.go
@@ -61,6 +61,11 @@ func receive(driver storagedriver.StorageDriver, receiver libchan.Receiver) {
 // Responds to requests using the Request.ResponseChannel
 func handleRequest(driver storagedriver.StorageDriver, request Request) {
 	switch request.Type {
+	case "Version":
+		err := request.ResponseChannel.Send(&VersionResponse{Version: storagedriver.CurrentVersion})
+		if err != nil {
+			panic(err)
+		}
 	case "GetContent":
 		path, _ := request.Parameters["Path"].(string)
 		content, err := driver.GetContent(path)

--- a/storagedriver/storagedriver.go
+++ b/storagedriver/storagedriver.go
@@ -3,7 +3,31 @@ package storagedriver
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 )
+
+// Version is a string representing the storage driver version, of the form Major.Minor.
+// The registry must accept storage drivers with equal major version and greater minor version,
+// but may not be compatible with older storage driver versions.
+type Version string
+
+// Major returns the major (primary) component of a version
+func (version Version) Major() uint {
+	majorPart := strings.Split(string(version), ".")[0]
+	major, _ := strconv.ParseUint(majorPart, 10, 0)
+	return uint(major)
+}
+
+// Minor returns the minor (secondary) component of a version
+func (version Version) Minor() uint {
+	minorPart := strings.Split(string(version), ".")[1]
+	minor, _ := strconv.ParseUint(minorPart, 10, 0)
+	return uint(minor)
+}
+
+// CurrentVersion is the current storage driver Version
+const CurrentVersion Version = "0.1"
 
 // StorageDriver defines methods that a Storage Driver must implement for a filesystem-like
 // key/value object storage


### PR DESCRIPTION
This adds a storage driver api version and a version check method that must be implemented for IPC storage drivers, which is called immediately after loading the driver.

The registry currently only accepts storage driver versions with the same major version and an equal or lower minor version as its own current storage driver api version, but this may be changed in the future if we decide to implement specific version cross-compatibility.
