### PR TITLE
Fixed #675: Added an ENV/Option to Configure USE_SIGV4

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Brad Ison <bison@garbagebrain.org>
 Brendan Burns <bburns@google.com>
 Chas Ballew <chas.ballew@gmail.com>
 Chris Tierney <notproperlycut@gmail.com>
+Christian Schmitt <c.schmitt@envisia.de>
 Christophe Furmaniak <christophe.furmaniak@gmail.com>
 Dan Trujillo <dtrupenn@gmail.com>
 Daniel Graña <dangra@gmail.com>

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ AWS Simple Storage Service options
       server-side by S3 and will be stored in an encrypted form while at rest
       in S3.
 1. `s3_secure`: boolean, true for HTTPS to S3
+1. `s3_use_sigv4`: boolean, true for USE_SIGV4 (boto_host needs to be set or use_sigv4 will be ignored by boto.)
 1. `boto_bucket`: string, the bucket name for *non*-Amazon S3-compliant object store
 1. `boto_host`: string, host for *non*-Amazon S3-compliant object store
 1. `boto_port`: for *non*-Amazon S3-compliant object store

--- a/config/config_sample.yml
+++ b/config/config_sample.yml
@@ -85,6 +85,7 @@ s3: &s3
     s3_secure: _env:AWS_SECURE:true
     s3_access_key: _env:AWS_KEY
     s3_secret_key: _env:AWS_SECRET
+    s3_use_sigv4: _env:AWS_USE_SIGV4
     boto_host: _env:AWS_HOST
     boto_port: _env:AWS_PORT
     boto_calling_format: _env:AWS_CALLING_FORMAT

--- a/docker_registry/drivers/s3.py
+++ b/docker_registry/drivers/s3.py
@@ -91,6 +91,12 @@ class Storage(coreboto.Base):
         else:
             self.signer = None
 
+        if self._config.s3_use_sigv4 is True:
+            if self._config.boto_host is None:
+                logger.warn("No S3 Host specified, Boto won't use SIGV4!")
+            boto.config.add_section('s3')
+            boto.config.set('s3', 'use-sigv4', 'True')
+
         if self._config.s3_region is not None:
             return boto.s3.connect_to_region(
                 region_name=self._config.s3_region,


### PR DESCRIPTION
Currently the new AWS SIGNATURE V4 wasn't supported by the docker_registry.
I created a ENV Variable called AWS_USE_SIGV4 which can either be true or false.
This could also be set using the Configuration S3_USE_SIGV4 inside a config file
