### PR TITLE
Removes quotes from GUNICORN_OPTS environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ required tables.  To avoid several Gunicorn workers racing to create
 the database, you should launch your registry with
 [--preload][gunicorn-preload].  For example:
 
-    $ docker run -e GUNICORN_OPTS='[--preload]' -p 5000:5000 registry
+    $ docker run -e GUNICORN_OPTS=[--preload] -p 5000:5000 registry
 
 ## Mirroring Options
 


### PR DESCRIPTION
When trying out the options for stopping the race condition outlined in this issue:

https://github.com/docker/docker-registry/issues/518

I ran into the following error:

``` bash
$: Traceback (most recent call last):
  File "/usr/local/bin/gunicorn", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 74, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/base.py", line 185, in run
    super(Application, self).run()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/base.py", line 71, in run
    Arbiter(self).run()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 169, in run
    self.manage_workers()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 477, in manage_workers
    self.spawn_workers()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 542, in spawn_workers
    time.sleep(0.1 * random.random())
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 209, in handle_chld
    self.reap_workers()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 459, in reap_workers
    raise HaltServer(reason, self.WORKER_BOOT_ERROR)
gunicorn.errors.HaltServer: <HaltServer 'Worker failed to boot.' 3>
2014-11-10 15:42:47 [15] [ERROR] Exception in worker process:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 507, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/ggevent.py", line 193, in init_process
    super(GeventWorker, self).init_process()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/base.py", line 114, in init_process
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/util.py", line 356, in import_app
    __import__(module)
ImportError: No module named [
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 507, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/ggevent.py", line 193, in init_process
    super(GeventWorker, self).init_process()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/base.py", line 114, in init_process
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/util.py", line 356, in import_app
    __import__(module)
ImportError: No module named [
```

which after chatting with the guys in that issue it was apparent the quotes weren't needed when specifying the options.
