### PR TITLE
docker_registry.lib.index.db: Support empty-query searches

### DIFF
--- a/docker_registry/lib/index/__init__.py
+++ b/docker_registry/lib/index/__init__.py
@@ -62,7 +62,7 @@ class Index (object):
     def _handle_repository_deleted(self, sender, namespace, repository):
         pass
 
-    def results(self, search_term):
+    def results(self, search_term=None):
         """Return a list of results matching search_term
 
         The list elements should be dictionaries:

--- a/docker_registry/lib/index/db.py
+++ b/docker_registry/lib/index/db.py
@@ -114,13 +114,15 @@ class SQLAlchemyIndex (Index):
         session.commit()
         session.close()
 
-    def results(self, search_term):
+    def results(self, search_term=None):
         session = self._session()
-        like_term = '%%%s%%' % search_term
-        repositories = session.query(Repository).filter(
-            sqlalchemy.sql.or_(
-                Repository.name.like(like_term),
-                Repository.description.like(like_term)))
+        repositories = session.query(Repository)
+        if search_term:
+            like_term = '%%%s%%' % search_term
+            repositories = repositories.filter(
+                sqlalchemy.sql.or_(
+                    Repository.name.like(like_term),
+                    Repository.description.like(like_term)))
         return [
             {
                 'name': repo.name,


### PR DESCRIPTION
Avoid building queries like:

```
SELECT
  repository.id AS repository_id,
  repository.name AS repository_name,
  repository.description AS repository_description
FROM repository
WHERE repository.name LIKE %% OR repository.description LIKE %%
```

When folks don't specify a query term.

Reported-by: Don Laidlaw don@donlaidlaw.ca

Fixes #719, but I haven't tested it ;).
