### PR TITLE
docker_registry.lib.index.db: Close session in SQLAlchemyIndex.results

### DIFF
--- a/docker_registry/lib/index/db.py
+++ b/docker_registry/lib/index/db.py
@@ -123,9 +123,11 @@ class SQLAlchemyIndex (Index):
                 sqlalchemy.sql.or_(
                     Repository.name.like(like_term),
                     Repository.description.like(like_term)))
-        return [
+        results = [
             {
                 'name': repo.name,
                 'description': repo.description,
             }
             for repo in repositories]
+        session.close()
+        return results


### PR DESCRIPTION
Reported in #719 [1](https://github.com/docker/docker-registry/issues/719#issuecomment-62907817).
