### PR TITLE
Adds ability to unwrap ipc errors into their original type

### DIFF
--- a/storagedriver/ipc/client.go
+++ b/storagedriver/ipc/client.go
@@ -126,7 +126,7 @@ func (driver *StorageDriverClient) Start() error {
 	}
 
 	if response.Error != nil {
-		return response.Error
+		return response.Error.Unwrap()
 	}
 
 	driver.version = response.Version
@@ -194,7 +194,7 @@ func (driver *StorageDriverClient) GetContent(path string) ([]byte, error) {
 	}
 
 	if response.Error != nil {
-		return nil, response.Error
+		return nil, response.Error.Unwrap()
 	}
 
 	defer response.Reader.Close()
@@ -226,7 +226,7 @@ func (driver *StorageDriverClient) PutContent(path string, contents []byte) erro
 	}
 
 	if response.Error != nil {
-		return response.Error
+		return response.Error.Unwrap()
 	}
 
 	return nil
@@ -253,7 +253,7 @@ func (driver *StorageDriverClient) ReadStream(path string, offset uint64) (io.Re
 	}
 
 	if response.Error != nil {
-		return nil, response.Error
+		return nil, response.Error.Unwrap()
 	}
 
 	return response.Reader, nil
@@ -280,7 +280,7 @@ func (driver *StorageDriverClient) WriteStream(path string, offset, size uint64,
 	}
 
 	if response.Error != nil {
-		return response.Error
+		return response.Error.Unwrap()
 	}
 
 	return nil
@@ -307,7 +307,7 @@ func (driver *StorageDriverClient) CurrentSize(path string) (uint64, error) {
 	}
 
 	if response.Error != nil {
-		return 0, response.Error
+		return 0, response.Error.Unwrap()
 	}
 
 	return response.Position, nil
@@ -334,7 +334,7 @@ func (driver *StorageDriverClient) List(path string) ([]string, error) {
 	}
 
 	if response.Error != nil {
-		return nil, response.Error
+		return nil, response.Error.Unwrap()
 	}
 
 	return response.Keys, nil
@@ -361,7 +361,7 @@ func (driver *StorageDriverClient) Move(sourcePath string, destPath string) erro
 	}
 
 	if response.Error != nil {
-		return response.Error
+		return response.Error.Unwrap()
 	}
 
 	return nil
@@ -387,7 +387,7 @@ func (driver *StorageDriverClient) Delete(path string) error {
 	}
 
 	if response.Error != nil {
-		return response.Error
+		return response.Error.Unwrap()
 	}
 
 	return nil

--- a/storagedriver/testsuites/testsuites.go
+++ b/storagedriver/testsuites/testsuites.go
@@ -126,6 +126,7 @@ func (suite *DriverSuite) TestReadNonexistent(c *check.C) {
 	filename := randomString(32)
 	_, err := suite.StorageDriver.GetContent(filename)
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 // TestWriteReadStreams1 tests a simple write-read streaming workflow
@@ -247,6 +248,7 @@ func (suite *DriverSuite) TestReadNonexistentStream(c *check.C) {
 	filename := randomString(32)
 	_, err := suite.StorageDriver.ReadStream(filename, 0)
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 // TestList checks the returned list of keys after populating a directory tree
@@ -297,6 +299,7 @@ func (suite *DriverSuite) TestMove(c *check.C) {
 
 	_, err = suite.StorageDriver.GetContent(sourcePath)
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 // TestMoveNonexistent checks that moving a nonexistent key fails
@@ -306,6 +309,7 @@ func (suite *DriverSuite) TestMoveNonexistent(c *check.C) {
 
 	err := suite.StorageDriver.Move(sourcePath, destPath)
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 // TestDelete checks that the delete operation removes data from the storage
@@ -324,6 +328,7 @@ func (suite *DriverSuite) TestDelete(c *check.C) {
 
 	_, err = suite.StorageDriver.GetContent(filename)
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 // TestDeleteNonexistent checks that removing a nonexistent key fails
@@ -331,6 +336,7 @@ func (suite *DriverSuite) TestDeleteNonexistent(c *check.C) {
 	filename := randomString(32)
 	err := suite.StorageDriver.Delete(filename)
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 // TestDeleteFolder checks that deleting a folder removes all child elements
@@ -354,9 +360,11 @@ func (suite *DriverSuite) TestDeleteFolder(c *check.C) {
 
 	_, err = suite.StorageDriver.GetContent(path.Join(dirname, filename1))
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 
 	_, err = suite.StorageDriver.GetContent(path.Join(dirname, filename2))
 	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, storagedriver.PathNotFoundError{})
 }
 
 func (suite *DriverSuite) writeReadCompare(c *check.C, filename string, contents, expected []byte) {


### PR DESCRIPTION
This only works for a specific whitelist of error types, which is currently all errors in the storagedriver package.

Also improves storagedriver tests to enforce proper error types are returned.

@stevvooe @dmp42 
