### PR TITLE
Move to own dev image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,14 +1,6 @@
-image: bradrydzewski/go:1.3
-
-env:
-  - GOROOT=/usr/local/go
-  - PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+image: dmp42/go:stable
 
 script:
-  - go get github.com/axw/gocov/gocov
-  - go get github.com/mattn/goveralls
-  - go get github.com/golang/lint/golint
-
   - go get -t ./...
 
   - FAIL=$(find ./ -iname "*.go" -exec gofmt -s -l {} \;) && echo "$FAIL" && test -z "$FAIL"

--- a/project/dev-image/Dockerfile
+++ b/project/dev-image/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:14.04
+
+ENV GOLANG_VERSION 1.4rc1
+ENV GOPATH /var/cache/drone
+ENV GOROOT /usr/local/go
+ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+
+ENV LANG C
+
+RUN apt-get update && apt-get install -y \
+  wget ca-certificates git mercurial bzr \
+  --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz --quiet && \
+  tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz && \
+  rm go${GOLANG_VERSION}.linux-amd64.tar.gz
+
+RUN go get github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/golang/lint/golint


### PR DESCRIPTION
Moving away from brad image into our own.
The dockerfile for that dev-image is also provided.
Benefits include:
- faster builds (since go get deps are now bundled in the base image)
- better control over exactly what we run on top of
- easier to get different versions of go
- simpler drone file
- way toward more unified bases tools for different projects
