### PR TITLE
[Client] Fix possible goroutine leak in pull

### DIFF
--- a/client/pull.go
+++ b/client/pull.go
@@ -36,7 +36,7 @@ func Pull(c Client, objectStore ObjectStore, name, tag string) error {
 		errChans[i] = make(chan error)
 	}
 
-	// To avoid leak goroutine we must notify
+	// To avoid leak of goroutines we must notify
 	// pullLayer goroutines about a cancelation,
 	// otherwise they will lock forever.
 	cancelCh := make(chan struct{})


### PR DESCRIPTION
Running goroutines with `pullLayer` are blocked to send error of a pull operation. If we abort pulling without notify them about cancelation they will get stucked forever. To avoid this possible leak `cancelCh` was introduced. In case of abort we close that channel to notify other goroutines about cancelation.
