### PR TITLE
Adds a test for concurrent storagedriver Write/Read Stream operations

### DIFF
--- a/storagedriver/ipc/client.go
+++ b/storagedriver/ipc/client.go
@@ -422,10 +422,10 @@ func (driver *StorageDriverClient) handleSubprocessExit() {
 // stopped
 func (driver *StorageDriverClient) receiveResponse(receiver libchan.Receiver, response interface{}) error {
 	receiveChan := make(chan error, 1)
-	go func(receiveChan chan<- error) {
+	go func(receiver libchan.Receiver, receiveChan chan<- error) {
 		defer close(receiveChan)
 		receiveChan <- receiver.Receive(response)
-	}(receiveChan)
+	}(receiver, receiveChan)
 
 	var err error
 	var ok bool


### PR DESCRIPTION
This test is currently failing and Skipped for IPC drivers, highlighting an issue that needs to be resolved.
