### PR TITLE
[IPC] Tiny cleaning

### DIFF
--- a/storagedriver/ipc/client.go
+++ b/storagedriver/ipc/client.go
@@ -423,7 +423,6 @@ func (driver *StorageDriverClient) handleSubprocessExit() {
 func (driver *StorageDriverClient) receiveResponse(receiver libchan.Receiver, response interface{}) error {
 	receiveChan := make(chan error, 1)
 	go func(receiver libchan.Receiver, receiveChan chan<- error) {
-		defer close(receiveChan)
 		receiveChan <- receiver.Receive(response)
 	}(receiver, receiveChan)
 
@@ -432,9 +431,6 @@ func (driver *StorageDriverClient) receiveResponse(receiver libchan.Receiver, re
 	select {
 	case err = <-receiveChan:
 	case err, ok = <-driver.exitChan:
-		go func(receiveChan <-chan error) {
-			<-receiveChan
-		}(receiveChan)
 		if !ok {
 			err = driver.exitErr
 		}


### PR DESCRIPTION
I did this PR just to find out the purpose of that part of code. My thoughts:
- `receiveChan` is buffered channel, so we have no deadlock. 
- possible `err` from `receiver.Receive` is disposed by gc even in the channel, so there's no memory/resource leak.
- Also I have no idea the purpose of closing `receiceChan`. 

May be some code is missing here?
