### PR TITLE
Clean up layer storage layout

### DIFF
--- a/storage/layer_test.go
+++ b/storage/layer_test.go
@@ -304,17 +304,12 @@ func writeTestLayer(driver storagedriver.StorageDriver, pathMapper *pathMapper, 
 	blobDigestSHA := digest.NewDigest("sha256", h)
 
 	blobPath, err := pathMapper.path(blobPathSpec{
-		alg:    blobDigestSHA.Algorithm(),
-		digest: blobDigestSHA.Hex(),
+		digest: dgst,
 	})
 
 	if err := driver.PutContent(blobPath, p); err != nil {
 		return "", err
 	}
-
-	layerIndexLinkPath, err := pathMapper.path(layerIndexLinkPathSpec{
-		digest: dgst,
-	})
 
 	if err != nil {
 		return "", err
@@ -329,11 +324,7 @@ func writeTestLayer(driver storagedriver.StorageDriver, pathMapper *pathMapper, 
 		return "", err
 	}
 
-	if err := driver.PutContent(layerLinkPath, []byte(blobDigestSHA.String())); err != nil {
-		return "", nil
-	}
-
-	if err = driver.PutContent(layerIndexLinkPath, []byte(name)); err != nil {
+	if err := driver.PutContent(layerLinkPath, []byte(dgst)); err != nil {
 		return "", nil
 	}
 

--- a/storage/paths_test.go
+++ b/storage/paths_test.go
@@ -28,20 +28,25 @@ func TestPathMapper(t *testing.T) {
 				name:   "foo/bar",
 				digest: digest.Digest("tarsum.v1+test:abcdef"),
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/layers/tarsum/v1/test/abcdef",
-		},
-		{
-			spec: layerIndexLinkPathSpec{
-				digest: digest.Digest("tarsum.v1+test:abcdef"),
-			},
-			expected: "/pathmapper-test/layerindex/tarsum/v1/test/abcdef",
+			expected: "/pathmapper-test/repositories/foo/bar/layers/tarsum/v1/test/ab/abcdef",
 		},
 		{
 			spec: blobPathSpec{
-				alg:    "sha512",
-				digest: "abcdefabcdefabcdef908909909",
+				digest: digest.Digest("tarsum.dev+sha512:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/pathmapper-test/blob/sha512/ab/abcdefabcdefabcdef908909909",
+			expected: "/pathmapper-test/blob/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909",
+		},
+		{
+			spec: blobPathSpec{
+				digest: digest.Digest("tarsum.v1+sha256:abcdefabcdefabcdef908909909"),
+			},
+			expected: "/pathmapper-test/blob/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909",
+		},
+		{
+			spec: blobPathSpec{
+				digest: digest.Digest("tarsum+sha256:abcdefabcdefabcdef908909909"),
+			},
+			expected: "/pathmapper-test/blob/tarsum/v0/sha256/ab/abcdefabcdefabcdef908909909",
 		},
 	} {
 		p, err := pm.path(testcase.spec)


### PR DESCRIPTION
Previously, discussions were still ongoing about different storage layouts that
could support various access models. This changeset removes a layer of
indirection that was in place due to earlier designs. Effectively, this both
associates a layer with a named repository and ensures that content cannot be
accessed across repositories. It also moves to rely on tarsum as a true
content-addressable identifier, removing a layer of indirection during blob
resolution.
