### PR TITLE
use m2crypto instead of rsa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
 before_install:
   - sudo apt-get update
   - sudo apt-get install redis-server
-  - sudo apt-get install libevent-dev liblzma-dev
+  - sudo apt-get install libevent-dev liblzma-dev libssl-dev
+  - sudo apt-get install swig
 
 install:
 ## This below should be separated when core lives elsewhere

--- a/docker_registry/lib/config.py
+++ b/docker_registry/lib/config.py
@@ -2,7 +2,8 @@
 
 import os
 
-import rsa
+from M2Crypto import BIO
+from M2Crypto import RSA
 import yaml
 
 from docker_registry.core import compat
@@ -109,7 +110,13 @@ def _init():
                 'Heads-up! File is missing: %s' % conf.privileged_key)
 
         try:
-            conf.privileged_key = rsa.PublicKey.load_pkcs1(f.read())
+            pk = f.read().split('\n')
+            pk = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A' + ''.join(pk[1:-2])
+            pk = [pk[i: i + 64] for i in range(0, len(pk), 64)]
+            pk = ('-----BEGIN PUBLIC KEY-----\n' + '\n'.join(pk) +
+                  '\n-----END PUBLIC KEY-----')
+            bio = BIO.MemoryBuffer(pk)
+            conf.privileged_key = RSA.load_pub_key_bio(bio)
         except Exception:
             raise exceptions.ConfigError(
                 'Key at %s is not a valid RSA key' % conf.privileged_key)

--- a/docker_registry/toolkit.py
+++ b/docker_registry/toolkit.py
@@ -11,8 +11,8 @@ import string
 import urllib
 
 import flask
+from M2Crypto import RSA
 import requests
-import rsa
 
 from docker_registry.core import compat
 json = compat.json
@@ -21,6 +21,7 @@ from . import storage
 from .lib import config
 
 cfg = config.load()
+
 logger = logging.getLogger(__name__)
 _re_docker_version = re.compile('docker/([^\s]+)')
 _re_authorization = re.compile(r'(\w+)[:=][\s"]?([^",]+)"?')
@@ -231,10 +232,9 @@ def check_signature():
     message = ','.join([flask.request.method, flask.request.path] +
                        ['{}:{}'.format(k, headers[k]) for k in header_keys])
     logger.debug('Signed message: {}'.format(message))
-    try:
-        return rsa.verify(message, sigdata, cfg.privileged_key)
-    except rsa.VerificationError:
+    if RSA.verify(cfg.privileged_key, sigdata, message, 'sha1') is False:
         return False
+    return True
 
 
 def parse_content_signature(s):

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,6 +4,6 @@ gevent==1.0.1
 gunicorn==19.1
 PyYAML==3.11
 requests==2.3.0
-rsa==3.1.4
+M2Crypto==0.22.3
 sqlalchemy==0.9.4
 setuptools==5.8


### PR DESCRIPTION
The pubkey is converted from PKCS#1 to X.501 format to be usable by
M2Crypto.

Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org

See: [upstream issue](https://bitbucket.org/sybren/python-rsa/issue/19/vulnerable-to-side-channel-attacks-on) and [relevant redhat bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1170703)

@dmp42 PTAL
