### PR TITLE
Fix Dockerfile to build with correct dependencies in master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ FROM ubuntu:14.04
 RUN apt-get update \
 # Install pip
     && apt-get install -y \
+        swig \
         python-pip \
 # Install deps for backports.lmza (python2 requires it)
         python-dev \
+        libssl-dev \
         liblzma-dev \
         libevent1-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The current Dockerfile in master is broken per current dependencies build requirements (not python requirements, but tools and headers for non-python build dependencies).  These two additions to the apt-get install command allow the Dockerfile to properly build a registry that can be run as a Docker container.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
