### PR TITLE
Relax requirement for size argument during blob upload

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -460,7 +460,10 @@ func pushLayer(t *testing.T, ub *v2.URLBuilder, name string, dgst digest.Digest,
 
 	u.RawQuery = url.Values{
 		"digest": []string{dgst.String()},
-		"size":   []string{fmt.Sprint(rsLength)},
+
+		// TODO(stevvooe): Layer upload can be completed with and without size
+		// argument. We'll need to add a test that checks the latter path.
+		"size": []string{fmt.Sprint(rsLength)},
 	}.Encode()
 
 	uploadURL := u.String()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -24,11 +24,11 @@ func TestPush(t *testing.T) {
 	tag := "sometag"
 	testBlobs := []testBlob{
 		{
-			digest:   "12345",
+			digest:   "tarsum.v2+sha256:12345",
 			contents: []byte("some contents"),
 		},
 		{
-			digest:   "98765",
+			digest:   "tarsum.v2+sha256:98765",
 			contents: []byte("some other contents"),
 		},
 	}
@@ -80,7 +80,6 @@ func TestPush(t *testing.T) {
 				Method: "PUT",
 				Route:  uploadLocations[i],
 				QueryParams: map[string][]string{
-					"length": {fmt.Sprint(len(blob.contents))},
 					"digest": {blob.digest.String()},
 				},
 				Body: blob.contents,
@@ -114,7 +113,10 @@ func TestPush(t *testing.T) {
 	})
 
 	server = httptest.NewServer(hack)
-	client := New(server.URL)
+	client, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("error creating client: %v", err)
+	}
 	objectStore := &memoryObjectStore{
 		mutex:           new(sync.Mutex),
 		manifestStorage: make(map[string]*storage.SignedManifest),
@@ -150,11 +152,11 @@ func TestPull(t *testing.T) {
 	tag := "sometag"
 	testBlobs := []testBlob{
 		{
-			digest:   "12345",
+			digest:   "tarsum.v2+sha256:12345",
 			contents: []byte("some contents"),
 		},
 		{
-			digest:   "98765",
+			digest:   "tarsum.v2+sha256:98765",
 			contents: []byte("some other contents"),
 		},
 	}
@@ -205,7 +207,10 @@ func TestPull(t *testing.T) {
 		},
 	}))
 	server := httptest.NewServer(handler)
-	client := New(server.URL)
+	client, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("error creating client: %v", err)
+	}
 	objectStore := &memoryObjectStore{
 		mutex:           new(sync.Mutex),
 		manifestStorage: make(map[string]*storage.SignedManifest),
@@ -259,11 +264,11 @@ func TestPullResume(t *testing.T) {
 	tag := "sometag"
 	testBlobs := []testBlob{
 		{
-			digest:   "12345",
+			digest:   "tarsum.v2+sha256:12345",
 			contents: []byte("some contents"),
 		},
 		{
-			digest:   "98765",
+			digest:   "tarsum.v2+sha256:98765",
 			contents: []byte("some other contents"),
 		},
 	}
@@ -329,7 +334,10 @@ func TestPullResume(t *testing.T) {
 
 	handler := testutil.NewHandler(layerRequestResponseMappings)
 	server := httptest.NewServer(handler)
-	client := New(server.URL)
+	client, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("error creating client: %v", err)
+	}
 	objectStore := &memoryObjectStore{
 		mutex:           new(sync.Mutex),
 		manifestStorage: make(map[string]*storage.SignedManifest),

--- a/storage/layer.go
+++ b/storage/layer.go
@@ -43,9 +43,14 @@ type LayerUpload interface {
 	// Offset returns the position of the last byte written to this layer.
 	Offset() int64
 
+	// TODO(stevvooe): Consider completely removing the size check from this
+	// interface. The digest check may be adequate and we are making it
+	// optional in the HTTP API.
+
 	// Finish marks the upload as completed, returning a valid handle to the
 	// uploaded layer. The final size and digest are validated against the
-	// contents of the uploaded layer.
+	// contents of the uploaded layer. If the size is negative, only the
+	// digest will be checked.
 	Finish(size int64, digest digest.Digest) (Layer, error)
 
 	// Cancel the layer upload process.
@@ -61,9 +66,6 @@ var (
 
 	// ErrLayerUploadUnknown returned when upload is not found.
 	ErrLayerUploadUnknown = fmt.Errorf("layer upload unknown")
-
-	// ErrLayerInvalidLength returned when length check fails.
-	ErrLayerInvalidLength = fmt.Errorf("invalid layer length")
 
 	// ErrLayerClosed returned when an operation is attempted on a closed
 	// Layer or LayerUpload.
@@ -86,4 +88,13 @@ type ErrLayerInvalidDigest struct {
 
 func (err ErrLayerInvalidDigest) Error() string {
 	return fmt.Sprintf("invalid digest for referenced layer: %v", err.FSLayer.BlobSum)
+}
+
+// ErrLayerInvalidSize returned when length check fails.
+type ErrLayerInvalidSize struct {
+	Size int64
+}
+
+func (err ErrLayerInvalidSize) Error() string {
+	return fmt.Sprintf("invalid layer size: %d", err.Size)
 }


### PR DESCRIPTION
During client implementation, it was found that requiring the size argument
made client implementation more complex. The original benefit of the size
argument was to provide an additional check alongside of tarsum to validate
incoming data. For the purposes of the registry, it has been determined that
tarsum should be enough to validate incoming content.

At this time, the size check is optional but we may consider removing it
completely.
