### PR TITLE
Use existing arch/os information for searches and index operations

### DIFF
--- a/docker_registry/lib/index/__init__.py
+++ b/docker_registry/lib/index/__init__.py
@@ -52,17 +52,17 @@ class Index (object):
                 yield({'name': name, 'description': description})
 
     def _handle_repository_created(
-            self, sender, namespace, repository, value):
+            self, sender, namespace, repository, value, arch, os):
         pass
 
     def _handle_repository_updated(
-            self, sender, namespace, repository, value):
+            self, sender, namespace, repository, value, arch, os):
         pass
 
     def _handle_repository_deleted(self, sender, namespace, repository):
         pass
 
-    def results(self, search_term=None):
+    def results(self, search_term=None, arch=None, os=None):
         """Return a list of results matching search_term
 
         The list elements should be dictionaries:

--- a/docker_registry/search.py
+++ b/docker_registry/search.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 
 from . import toolkit
 from .app import app
@@ -7,18 +8,30 @@ from .lib import index
 from .lib import mirroring
 import flask
 
-
 cfg = config.load()
 
 # Enable the search index
 INDEX = index.load(cfg.search_backend.lower())
 
+RE_USER_AGENT = re.compile('([^\s/]+)/([^\s/]+)')
+
 
 @app.route('/v1/search', methods=['GET'])
 @mirroring.source_lookup(index_route=True, merge_results=True)
 def get_search():
+    # default to standard 64-bit linux, then check UA for
+    # specific arch/os (if coming from a docker host)
+    arch = 'amd64'
+    os = 'linux'
+    user_agent = flask.request.headers.get('user-agent', '')
+    ua = dict(RE_USER_AGENT.findall(user_agent))
+    if 'arch' in ua:
+        arch = ua['arch']
+    if 'os' in ua:
+        os = ua['os']
+
     search_term = flask.request.args.get('q', '')
-    results = INDEX.results(search_term=search_term)
+    results = INDEX.results(search_term=search_term, arch=arch, os=os)
     return toolkit.response({
         'query': search_term,
         'num_results': len(results),

--- a/tests/lib/index/test__init__.py
+++ b/tests/lib/index/test__init__.py
@@ -11,8 +11,10 @@ class TestIndex(unittest.TestCase):
         self.index = index.Index()
 
     def test_cover_passed_methods(self):
-        self.index._handle_repository_created(None, None, None, None)
-        self.index._handle_repository_updated(None, None, None, None)
+        self.index._handle_repository_created(None, None, None, None, None,
+                                              None)
+        self.index._handle_repository_updated(None, None, None, None, None,
+                                              None)
         self.index._handle_repository_deleted(None, None, None)
 
     def test_results(self):


### PR DESCRIPTION
This code is a first step in making the current registry aware of
images for non-Intel architecture.  While os==linux today, if
we are adding architecture we might as well add both `arch` and
`os` for future use by Microsoft and/or others where os != linux.

Signed-off-by: Pradipta Kr. Banerjee bpradip@in.ibm.com
Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com
