### PR TITLE
NG: Use filesystem driver in default configuration

### DIFF
--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -1,5 +1,7 @@
 version: 0.1
 loglevel: debug
-storage: inmemory
+storage:
+    filesystem:
+        rootdirectory: /tmp/registry-dev
 http:
     addr: :5000


### PR DESCRIPTION
It makes way more sense to define a default configuration with the filesystem driver rather than the inmemory driver. Its pointed at a temp directory for now, which may cause problems.
