### PR TITLE
Allows HTTP bind address to be overridden by an environment variable

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -311,6 +311,10 @@ func parseV0_1Registry(in []byte) (*Configuration, error) {
 		config.Reporting.NewRelic.Name = newRelicName
 	}
 
+	if httpAddr, ok := envMap["REGISTRY_HTTP_ADDR"]; ok {
+		config.HTTP.Addr = httpAddr
+	}
+
 	return (*Configuration)(&config), nil
 }
 


### PR DESCRIPTION
Uses REGISTRY_HTTP_ADDR

@stevvooe 
