### PR TITLE
Fixes Dockerfile "go get" command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang
 COPY . /go/src/github.com/docker/docker-registry
 
 # Fetch any dependencies to run the registry
-RUN go get github.com/docker/docker-registry
+RUN go get github.com/docker/docker-registry/...
 RUN go install github.com/docker/docker-registry/cmd/registry
 
 ENV CONFIG_PATH /etc/docker/registry/config.yml


### PR DESCRIPTION
Now pulls down all dependencies for registry sub-packages

@dmp42 @stevvooe 
