### PR TITLE
Ensure that unset Context.Name only allowed on base route

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -177,6 +177,11 @@ func TestNewApp(t *testing.T) {
 		t.Fatalf("unexpected content-type: %v != %v", req.Header.Get("Content-Type"), "application/json")
 	}
 
+	expectedAuthHeader := "Bearer realm=\"realm-test\",service=\"service-test\""
+	if req.Header.Get("Authorization") != expectedAuthHeader {
+		t.Fatalf("unexpected authorization header: %q != %q", req.Header.Get("Authorization"), expectedAuthHeader)
+	}
+
 	var errs v2.Errors
 	dec := json.NewDecoder(req.Body)
 	if err := dec.Decode(&errs); err != nil {

--- a/auth/silly/access.go
+++ b/auth/silly/access.go
@@ -51,7 +51,7 @@ func (ac *accessController) Authorized(req *http.Request, accessRecords ...auth.
 		if len(accessRecords) > 0 {
 			var scopes []string
 			for _, access := range accessRecords {
-				scopes = append(scopes, fmt.Sprintf("%s:%s:%s", access.Type, access.Resource, access.Action))
+				scopes = append(scopes, fmt.Sprintf("%s:%s:%s", access.Type, access.Resource.Name, access.Action))
 			}
 			challenge.scope = strings.Join(scopes, " ")
 		}


### PR DESCRIPTION
If Context.Name is not set, the acceess controller may allow an unintended
request through. By only allowing a request to proceed without a name on the
base route, we provide some protection if future bugs forget to set the context
properly.

@jlhawn @dmcgowan @dmp42 
