### PR TITLE
Add the secure flag for the s3 driver

### DIFF
--- a/storagedriver/s3/s3_test.go
+++ b/storagedriver/s3/s3_test.go
@@ -21,6 +21,7 @@ func init() {
 	secretKey := os.Getenv("AWS_SECRET_KEY")
 	bucket := os.Getenv("S3_BUCKET")
 	encrypt := os.Getenv("S3_ENCRYPT")
+	secure := os.Getenv("S3_SECURE")
 	region := os.Getenv("AWS_REGION")
 	root, err := ioutil.TempDir("", "driver-")
 	if err != nil {
@@ -28,11 +29,19 @@ func init() {
 	}
 
 	s3DriverConstructor := func(region aws.Region) (storagedriver.StorageDriver, error) {
-		shouldEncrypt, err := strconv.ParseBool(encrypt)
+		encryptBool, err := strconv.ParseBool(encrypt)
 		if err != nil {
 			return nil, err
 		}
-		return New(accessKey, secretKey, bucket, root, region, shouldEncrypt)
+
+		secureBool := true
+		if secure != "" {
+			secureBool, err = strconv.ParseBool(secure)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return New(accessKey, secretKey, bucket, root, region, encryptBool, secureBool)
 	}
 
 	// Skip S3 storage driver tests if environment variable parameters are not provided


### PR DESCRIPTION
The secure flag will be true by default and will change the
s3 endpoint of the region to http instead of https when selected as false.
The main benefits of running with secure being false is that it apparently
has a roughly 33% performance boost (even on pure data transfer, not only
connection setup which is what I would have expected).
