### PR TITLE
fix registry._setup_database.lock remove issue

### DIFF
--- a/docker_registry/toolkit.py
+++ b/docker_registry/toolkit.py
@@ -327,7 +327,8 @@ def exclusive_lock(f):
         try:
             result = f(*args, **kwargs)
         finally:
-            os.remove(lock_path)
+            if os.path.exists(lock_path):
+                os.remove(lock_path)
         return result
     return wrapper
 


### PR DESCRIPTION
It will try to remove non-existing registry._setup_database.lock
when search_backend setting to sqlalchemy

Signed-off-by: Harrison Feng <harrison_feng@163.com>