### PR TITLE
Fix DISABLE_TOKEN_AUTH flag check in docker_registry/toolkit.py

### DIFF
--- a/docker_registry/toolkit.py
+++ b/docker_registry/toolkit.py
@@ -119,7 +119,7 @@ def response(data=None, code=200, headers=None, raw=False):
 
 
 def validate_parent_access(parent_id):
-    if cfg.standalone:
+    if cfg.disable_token_auth is True or cfg.standalone is True:
         return True
     auth = _parse_auth_header()
     if not auth:


### PR DESCRIPTION
When we set DISABLE_TOKEN_AUTH to true, there are two functions that
should check the flag, but only one function does.

So we add the check in both check_token() and validate_parent_access().

Signed-off-by: Guo Xiuyan guoxiuyan@huawei.com
