### PR TITLE
Update ADVANCED.md

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -136,7 +136,7 @@ If you don't want to run the registry inside a docker container, you may do so b
 Install the system requirements:
 
 ```
-sudo apt-get install python-dev libevent-dev python-pip liblzma-dev
+sudo apt-get install python-dev libevent-dev python-pip liblzma-dev swig libssl-devel
 ```
 
 Then install the Registry app:


### PR DESCRIPTION
Fix missing install requirements for Ubuntu. 

On a base Ubuntu 14.04.1 LTS x64 install (just openssh-server selected during install)

The following error occurs for not having swig

running build_ext

building 'M2Crypto.__m2crypto' extension

swigging SWIG/_m2crypto.i to SWIG/_m2crypto_wrap.c

swig -python -I/usr/include/python2.7 -I/usr/include/x86_64-linux-gnu -I/usr/include -I/usr/include/openssl -includeall -modern -o SWIG/_m2crypto_wrap.c SWIG/_m2crypto.i

unable to execute 'swig': No such file or directory

error: command 'swig' failed with exit status 1

----------------------------------------
Cleaning up...
Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/M2Crypto/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-i2bDKn-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/M2Crypto
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.4', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 185, in main
    return command.main(cmd_args)
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 161, in main
    text = '\n'.join(complete_log)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 33: ordinal not in range(128)


The following error occurs for not having libssl-dev

running build_ext

building 'M2Crypto.__m2crypto' extension

swigging SWIG/_m2crypto.i to SWIG/_m2crypto_wrap.c

swig -python -I/usr/include/python2.7 -I/usr/include/x86_64-linux-gnu -I/usr/include -I/usr/include/openssl -includeall -modern -o SWIG/_m2crypto_wrap.c SWIG/_m2crypto.i

SWIG/_m2crypto.i:30: Error: Unable to find 'openssl/opensslv.h'

SWIG/_m2crypto.i:33: Error: Unable to find 'openssl/safestack.h'

SWIG/_evp.i:12: Error: Unable to find 'openssl/opensslconf.h'

SWIG/_ec.i:7: Error: Unable to find 'openssl/opensslconf.h'

error: command 'swig' failed with exit status 1

----------------------------------------
Cleaning up...
Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/M2Crypto/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-vZ0I6V-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/M2Crypto
Storing debug log for failure in /home/netalien/.pip/pip.log