### PR TITLE
Missing `index_endpoint` in mirror config

### DIFF
--- a/config/config_mirror.yml
+++ b/config/config_mirror.yml
@@ -1,6 +1,7 @@
 # The `common' part is automatically included (and possibly overriden by all
 # other flavors)
 common: &common
+    index_endpoint: https://index.docker.io
     mirroring:
         source: https://registry-1.docker.io
         source_index: https://index.docker.io


### PR DESCRIPTION
Without an `index_endpoint` entry, `docker-registry` fails with the following errors:

```
01/Mar/2015:13:02:44 +0000 DEBUG: args = {'image_id': u'868be653dea3ff6082b043c0f34b95bb180cc82ab14a18d9d6b8e27b7929762c'}
01/Mar/2015:13:02:44 +0000 DEBUG: Auth Token = Token signature=d0b68cf62d0eb1cc3fc2ad42ad1a2b16111b1504,repository="library/redis",access=read
01/Mar/2015:13:02:44 +0000 DEBUG: auth = {u'access': u'read', u'repository': u'library/redis', u'signature': u'd0b68cf62d0eb1cc3fc2ad42ad1a2b16111b1504'}
2015-03-01 13:02:44,178 ERROR: Exception on /v1/images/868be653dea3ff6082b043c0f34b95bb180cc82ab14a18d9d6b8e27b7929762c/ancestry [GET]
Traceback (most recent call last):
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/docker_registry/toolkit.py", line 279, in wrapper
    if check_signature() is True or check_token(kwargs) is True:
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/docker_registry/toolkit.py", line 231, in check_token
    if validate_token(auth) is False:
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/docker_registry/toolkit.py", line 159, in validate_token
    resp = requests.get(url, verify=True, headers=headers)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/requests/api.py", line 55, in get
    return request('get', url, **kwargs)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/requests/sessions.py", line 422, in request
    prep = self.prepare_request(req)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/requests/sessions.py", line 360, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/requests/models.py", line 294, in prepare
    self.prepare_url(url, params)
  File "/srv/docker-registry/virtualenv/local/lib/python2.7/site-packages/requests/models.py", line 345, in prepare_url
    "Perhaps you meant http://{0}?".format(url))
MissingSchema: Invalid URL u'None/v1/repositories/library/redis/images': No schema supplied. Perhaps you meant http://None/v1/repositories/library/redis/images?
```