### PR TITLE
Support GET /v1/repositories/library/(.*?)/tags

### DIFF
--- a/contrib/golang_impl/handler.go
+++ b/contrib/golang_impl/handler.go
@@ -225,6 +225,7 @@ func NewHandler(dataDir string) (handler *Handler) {
 	handler.Map("PUT", "images/(.*?)/(.*)", handler.PutImageResource)
 
 	// repositories
+        handler.Map("GET", "repositories/library/(.*?)/tags", handler.GetRepositoryTags)
 	handler.Map("GET", "repositories/(.*?)/tags", handler.GetRepositoryTags)
 	handler.Map("GET", "repositories/(.*?)/images", handler.GetRepositoryImages)
 	handler.Map("PUT", "repositories/(.*?)/tags/(.*)", handler.PutRepositoryTags)


### PR DESCRIPTION
I found that I was unable to pull a tagged image from the master golang_impl due to the Docker pull sending "library/" as a prefix to the repoName in the HTTP GET. Since the repoName unexpectedly included "library/", GetRepositoryTags was returning an empty JSON object, and the image could not be located. This resolves the problem by allowing the portion after "library/" to be passed to the existing handler as it expects. My client and server API versions at the time of the failure (and resultant fix) were as follows -

Client version: 1.3.2
Client API version: 1.15
Go version (client): go1.3.3
Git commit (client): 39fa2fa
OS/Arch (client): linux/amd64
Server version: 1.3.2
Server API version: 1.15
Go version (server): go1.3.3
Git commit (server): 39fa2fa