### PR TITLE
Add a missing env value for Cloudfront in ADVANCED.md

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -222,6 +222,7 @@ This flavor can be started as:
  ```
 docker run \
          -e SETTINGS_FLAVOR=cloudfronts3 \
+         -e STORAGE_REDIRECT=true \
          -e AWS_BUCKET=mybucket \
          -e STORAGE_PATH=/registry \
          -e AWS_KEY=myawskey \


### PR DESCRIPTION
The `STORAGE_REDIRECT` is disabled by default so we should specify `STORAGE_REDIRECT=true` in docker run command as an env value.