### PR TITLE
Update apache.conf

### DIFF
--- a/contrib/apache.conf
+++ b/contrib/apache.conf
@@ -39,5 +39,11 @@
                 Allow from all
         </Location>
 
+        # Allow ping and users to run unauthenticated.
+        <Location /_ping>
+               Satisfy any
+               Allow from all
+        </Location>
+
 </VirtualHost>
 

--- a/contrib/apache.conf
+++ b/contrib/apache.conf
@@ -11,6 +11,11 @@
 
         ProxyRequests     off
         ProxyPreserveHost on
+
+        # Some HTTPd came configured with /error for error messages
+        # In this case, you should disable proxying to remote docker-registry
+        # ProxyPass /error/ !
+        
         ProxyPass         / http://127.0.0.1:5000/
         ProxyPassReverse  / http://127.0.0.1:5000/
 


### PR DESCRIPTION
Some Apache distribution came with following error handling

    Alias /error/ "/usr/share/apache2/error/"

    <IfModule mod_negotiation.c>
    <IfModule mod_include.c>
        <Directory "/usr/share/apache2/error">
            AllowOverride None
            Options IncludesNoExec
            AddOutputFilter Includes html
            AddHandler type-map var
            Require all granted
            LanguagePriority en cs de es fr it ja ko nl pl pt-br ro sv tr
            ForceLanguagePriority Prefer Fallback
        </Directory>
        
        ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
        ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
        ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
        ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
        ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
        ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
        ErrorDocument 410 /error/HTTP_GONE.html.var
        ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
        ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
        ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
        ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
        ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
        ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
        ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
        ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
        ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
        ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
    </IfModule>
    </IfModule>

In this case, you shouldn't proxy /error/ to docker-registry 