### PR TITLE
Update Registry 2.0 Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WARNING
 ===============
 
-> **Notice:** *The classical python "Docker Registry" is deprecated, in favor of a new golang implementation. This here is kept for historical purpose, and will not receive any significant work/love any more.  You should head to [the landing page of the new registry](https://docs.docker.com/registry) or  [the "Distribution" github project](https://github.com/docker/distribution) instead.*
+> **Notice:** *The classical python "Docker Registry" is deprecated, in favor of a new golang implementation. This here is kept for historical purpose, and will not receive any significant work/love any more.  You should head to [the landing page of the new registry](https://docs.docker.com/registry/overview/) or  [the "Distribution" github project](https://github.com/docker/distribution) instead.*
 
 Docker-Registry
 ===============


### PR DESCRIPTION
Current link is a 404. This changes it to what I believe was the intended URL.