### PR TITLE
set validate=False when calling boto get_bucket

### DIFF
--- a/depends/docker-registry-core/docker_registry/core/boto.py
+++ b/depends/docker-registry-core/docker_registry/core/boto.py
@@ -131,7 +131,7 @@ class Base(driver.Base):
         self._root_path = path or '/test'
         self._boto_conn = self.makeConnection()
         self._boto_bucket = self._boto_conn.get_bucket(
-            self._config.boto_bucket)
+            self._config.boto_bucket, validate=False)
         logger.info("Boto based storage initialized")
 
     def _build_connection_params(self):


### PR DESCRIPTION
Hi folks,

By passing validate=False to boto get_bucket I can use a bucket where my account doesn't have permission to the root, but has permission to a sub path in which I'm storing the docker registry.

thanks much!
-Kirat