### PR TITLE
Caller of check_signature expects a bool

### DIFF
--- a/docker_registry/toolkit.py
+++ b/docker_registry/toolkit.py
@@ -253,7 +253,7 @@ def check_signature():
                        ['{}:{}'.format(k, headers[k]) for k in header_keys])
     logger.debug('Signed message: {}'.format(message))
     try:
-        return pkey.verify(message_digest(message), sigdata, 'sha1')
+        return pkey.verify(message_digest(message), sigdata, 'sha1') == 1
     except RSA.RSAError as e:
         logger.exception(e)
         return False


### PR DESCRIPTION
The recent changes to the underlying RSA library has
changed the way verify works.  Verify now returns a 1 for
success, yet callers to check_signature were expecting a boolean.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>